### PR TITLE
chore: tokenize SCSS hardcoded values for M3 consolidation

### DIFF
--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/edit/dashboard-chart-edit/dashboard-chart-edit.component.scss
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/edit/dashboard-chart-edit/dashboard-chart-edit.component.scss
@@ -2,6 +2,6 @@
   max-width: 1300px;
   overflow: scroll;
   overflow-y: hidden;
-  background-color: #FFFFFF !important;
+  background-color: var(--bg, #FFFFFF) !important;
   padding-bottom: 15px;
 }

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-view/dashboard-chart-view.component.scss
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-view/dashboard-chart-view.component.scss
@@ -2,7 +2,7 @@
   max-width: 1500px;
   overflow: scroll;
   overflow-y: hidden;
-  background-color: #FFFFFF !important;
+  background-color: var(--bg, #FFFFFF) !important;
   padding-bottom: 15px;
 }
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `#FFFFFF` background-color with `var(--bg, #FFFFFF)` in dashboard chart edit and view components
- Part of platform-wide M3 token consolidation

## Test plan
- [ ] Verify insight dashboard chart edit/view pages render correctly
- [ ] Verify background color unchanged visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)