### PR TITLE
fix: exclude soft-deleted answers from charts as well as raw data

### DIFF
--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswerFilterHelperUTests.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswerFilterHelperUTests.cs
@@ -55,6 +55,7 @@ public class AnswerFilterHelperUTests : DbTestFixture
         var candidate = await DbContext.AnswerValues
             .AsNoTracking()
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => x.Answer.WorkflowState != Constants.WorkflowStates.Removed)
             .GroupBy(x => new { x.Answer.QuestionSetId, x.QuestionId })
             .Select(g => new { g.Key.QuestionSetId, g.Key.QuestionId, Count = g.Count() })
             .OrderByDescending(x => x.Count)
@@ -101,6 +102,7 @@ public class AnswerFilterHelperUTests : DbTestFixture
         var scope = DbContext.AnswerValues
             .AsNoTracking()
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => x.Answer.WorkflowState != Constants.WorkflowStates.Removed)
             .Where(x => x.Answer.QuestionSetId == survey.Key);
 
         var materialisedIds = await scope
@@ -136,6 +138,7 @@ public class AnswerFilterHelperUTests : DbTestFixture
         var pick = await DbContext.AnswerValues
             .AsNoTracking()
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => x.Answer.WorkflowState != Constants.WorkflowStates.Removed)
             .GroupBy(x => new { x.Answer.QuestionSetId, x.QuestionId, x.OptionId })
             .Select(g => new { g.Key.QuestionSetId, g.Key.QuestionId, g.Key.OptionId, Count = g.Count() })
             .OrderByDescending(x => x.Count)
@@ -162,6 +165,7 @@ public class AnswerFilterHelperUTests : DbTestFixture
         var scope = DbContext.AnswerValues
             .AsNoTracking()
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => x.Answer.WorkflowState != Constants.WorkflowStates.Removed)
             .Where(x => x.Answer.QuestionSetId == pick.QuestionSetId);
 
         var materialisedIds = await scope
@@ -191,6 +195,7 @@ public class AnswerFilterHelperUTests : DbTestFixture
         var repeated = await DbContext.AnswerValues
             .AsNoTracking()
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => x.Answer.WorkflowState != Constants.WorkflowStates.Removed)
             .GroupBy(x => new { x.AnswerId, x.QuestionId })
             .Where(g => g.Count() > 1)
             .Select(g => new { g.Key.AnswerId, g.Key.QuestionId })
@@ -447,15 +452,16 @@ public class AnswerFilterHelperUTests : DbTestFixture
     /// Regression test for the 57-vs-53 discrepancy on a real dashboard.
     ///
     /// Four answers had Answers.WorkflowState='removed' while their AnswerValues
-    /// stayed 'created' - a state the application cannot produce (its delete
-    /// removes the values first), so it arrived via direct SQL. Charts filtered
-    /// only the value's workflow state and counted them; the raw data table also
-    /// filtered the answer's and did not. The two disagreed in production.
+    /// stayed 'created'. Charts filtered only the value's workflow state and
+    /// counted them; the raw data table also filtered the answer's and did not.
+    /// The two disagreed on a real dashboard: 57 against 53.
     ///
-    /// This reproduces that state exactly and asserts both paths now agree. It
-    /// mutates the shared test database, so the change is undone in a finally -
-    /// and deliberately does so with raw SQL rather than PnBase.Delete, because
-    /// Delete would also remove the values and destroy the very state under test.
+    /// How answers reach that state is not established - the delete path removes
+    /// the values first, so a half-completed delete leaves the opposite skew - but
+    /// the state demonstrably exists in real data, and every reader of it has to
+    /// agree. That is what this pins.
+    ///
+    /// This reproduces that state exactly and asserts both paths now agree.
     /// </summary>
     [Test]
     public async Task RemovedAnswerWithLiveValues_IsExcludedFromChartsAndRawDataAlike()
@@ -466,6 +472,7 @@ public class AnswerFilterHelperUTests : DbTestFixture
             .AsNoTracking()
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
             .Where(x => x.Answer.WorkflowState != Constants.WorkflowStates.Removed)
+            .OrderBy(x => x.AnswerId)
             .Select(x => new
             {
                 x.AnswerId,
@@ -516,9 +523,23 @@ public class AnswerFilterHelperUTests : DbTestFixture
             chartBefore.OrderBy(x => x), Is.EqualTo(rawBefore.OrderBy(x => x)),
             "Chart and raw data must agree before the answer is touched.");
 
-        try
+        // Everything below runs inside a transaction that is never committed, so
+        // the shared database is unchanged even if this process is killed. A
+        // try/finally restore would not survive that, and DbTestFixture.ClearDb
+        // is a no-op, so nothing else would put the row back.
+        //
+        // The context is configured with MySqlRetryingExecutionStrategy, which
+        // refuses user-initiated transactions unless the whole unit runs through
+        // the strategy - hence the wrapper rather than a bare BeginTransaction.
+        var strategy = DbContext.Database.CreateExecutionStrategy();
+
+        await strategy.ExecuteAsync(async () =>
         {
-            // The exact broken state: answer removed, values untouched.
+            await using var transaction = await DbContext.Database.BeginTransactionAsync();
+
+            // The exact broken state: answer removed, values untouched. Raw SQL
+            // rather than PnBase.Delete, which would remove the values too and
+            // destroy the case under test.
             await DbContext.Database.ExecuteSqlRawAsync(
                 "UPDATE Answers SET WorkflowState = 'removed' WHERE Id = {0}", subject.AnswerId);
 
@@ -546,16 +567,13 @@ public class AnswerFilterHelperUTests : DbTestFixture
 
             Assert.That(chartAfter.Count, Is.EqualTo(chartBefore.Count - 1),
                 "Exactly the one soft-deleted answer should have dropped out.");
-        }
-        finally
-        {
-            await DbContext.Database.ExecuteSqlRawAsync(
-                "UPDATE Answers SET WorkflowState = 'created' WHERE Id = {0}", subject.AnswerId);
-        }
+
+            await transaction.RollbackAsync();
+        });
 
         // The database must be exactly as it was, or later tests inherit the bug.
         var chartRestored = await ChartAnswerIds();
         Assert.That(chartRestored.OrderBy(x => x), Is.EqualTo(chartBefore.OrderBy(x => x)),
-            "Cleanup failed - the shared test database is left modified.");
+            "Rollback failed - the shared test database is left modified.");
     }
 }

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswerFilterHelperUTests.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswerFilterHelperUTests.cs
@@ -442,4 +442,120 @@ public class AnswerFilterHelperUTests : DbTestFixture
 
         Assert.That(first.Id, Is.EqualTo(2));
     }
+
+    /// <summary>
+    /// Regression test for the 57-vs-53 discrepancy on a real dashboard.
+    ///
+    /// Four answers had Answers.WorkflowState='removed' while their AnswerValues
+    /// stayed 'created' - a state the application cannot produce (its delete
+    /// removes the values first), so it arrived via direct SQL. Charts filtered
+    /// only the value's workflow state and counted them; the raw data table also
+    /// filtered the answer's and did not. The two disagreed in production.
+    ///
+    /// This reproduces that state exactly and asserts both paths now agree. It
+    /// mutates the shared test database, so the change is undone in a finally -
+    /// and deliberately does so with raw SQL rather than PnBase.Delete, because
+    /// Delete would also remove the values and destroy the very state under test.
+    /// </summary>
+    [Test]
+    public async Task RemovedAnswerWithLiveValues_IsExcludedFromChartsAndRawDataAlike()
+    {
+        // An answer that is currently selected, together with the question it
+        // answered and the site it came from.
+        var subject = await DbContext.AnswerValues
+            .AsNoTracking()
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => x.Answer.WorkflowState != Constants.WorkflowStates.Removed)
+            .Select(x => new
+            {
+                x.AnswerId,
+                x.QuestionId,
+                x.Answer.SiteId,
+                x.Answer.QuestionSetId,
+            })
+            .FirstOrDefaultAsync();
+
+        Assert.That(subject, Is.Not.Null, "Seed data has no live answer to work with.");
+
+        var dashboardItem = new DashboardItem
+        {
+            FirstQuestionId = subject.QuestionId,
+            IgnoredAnswerValues = new List<DashboardItemIgnoredAnswer>(),
+            CompareLocationsTags = new List<DashboardItemCompare>(),
+        };
+
+        // Mirrors how CalculateDashboardItem composes the filter for a
+        // non-compared item: the shared filter, then the dashboard location.
+        async Task<List<int>> ChartAnswerIds() =>
+            await AnswerFilterHelper.ApplyLocationFilter(
+                    AnswerFilterHelper.BuildFilteredAnswerValues(
+                        DbContext, dashboardItem, subject.QuestionSetId, new DashboardEditAnswerDates()),
+                    subject.SiteId,
+                    null)
+                .Select(x => x.AnswerId)
+                .Distinct()
+                .ToListAsync();
+
+        async Task<List<int>> RawDataAnswerIds() =>
+            await AnswerFilterHelper.BuildAnswerQuery(
+                    DbContext,
+                    dashboardItem,
+                    subject.QuestionSetId,
+                    subject.SiteId,
+                    null,
+                    new DashboardEditAnswerDates())
+                .Select(x => x.Id)
+                .ToListAsync();
+
+        var chartBefore = await ChartAnswerIds();
+        var rawBefore = await RawDataAnswerIds();
+
+        Assert.That(chartBefore, Does.Contain(subject.AnswerId),
+            "The chosen answer must start out selected, or the test proves nothing.");
+        Assert.That(
+            chartBefore.OrderBy(x => x), Is.EqualTo(rawBefore.OrderBy(x => x)),
+            "Chart and raw data must agree before the answer is touched.");
+
+        try
+        {
+            // The exact broken state: answer removed, values untouched.
+            await DbContext.Database.ExecuteSqlRawAsync(
+                "UPDATE Answers SET WorkflowState = 'removed' WHERE Id = {0}", subject.AnswerId);
+
+            var liveValues = await DbContext.AnswerValues
+                .AsNoTracking()
+                .Where(x => x.AnswerId == subject.AnswerId)
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .CountAsync();
+
+            Assert.That(liveValues, Is.GreaterThan(0),
+                "The answer's values must still be live, otherwise this is an ordinary delete.");
+
+            var chartAfter = await ChartAnswerIds();
+            var rawAfter = await RawDataAnswerIds();
+
+            Assert.That(chartAfter, Does.Not.Contain(subject.AnswerId),
+                "A soft-deleted answer must not feed a chart, even when its values are live.");
+            Assert.That(rawAfter, Does.Not.Contain(subject.AnswerId),
+                "A soft-deleted answer must not appear in the raw data table.");
+
+            Assert.That(
+                chartAfter.OrderBy(x => x), Is.EqualTo(rawAfter.OrderBy(x => x)),
+                "Chart and raw data must still agree once an answer is soft-deleted - "
+                + "this is the invariant that broke and produced 57 against 53.");
+
+            Assert.That(chartAfter.Count, Is.EqualTo(chartBefore.Count - 1),
+                "Exactly the one soft-deleted answer should have dropped out.");
+        }
+        finally
+        {
+            await DbContext.Database.ExecuteSqlRawAsync(
+                "UPDATE Answers SET WorkflowState = 'created' WHERE Id = {0}", subject.AnswerId);
+        }
+
+        // The database must be exactly as it was, or later tests inherit the bug.
+        var chartRestored = await ChartAnswerIds();
+        Assert.That(chartRestored.OrderBy(x => x), Is.EqualTo(chartBefore.OrderBy(x => x)),
+            "Cleanup failed - the shared test database is left modified.");
+    }
 }

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Helpers/AnswerFilterHelper.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Helpers/AnswerFilterHelper.cs
@@ -197,6 +197,10 @@ public static class AnswerFilterHelper
             ? ComparedAnswerIds(answerValues, dashboardItem, dashboardLocationId, dashboardLocationTagId)
             : NonComparedAnswerIds(answerValues, dashboardLocationId, dashboardLocationTagId);
 
+        // The workflow-state clause is redundant - every id in answerIds already
+        // came through WhereAnswerIsLive - but it is a cheap, index-friendly guard
+        // on the outer scan and it keeps this query correct on its own terms if
+        // answerIds is ever built differently. Deliberate, not leftover.
         return sdkContext.Answers
             .AsNoTracking()
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Helpers/AnswerFilterHelper.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Helpers/AnswerFilterHelper.cs
@@ -47,12 +47,23 @@ using Models.Dashboards;
 public static class AnswerFilterHelper
 {
     /// <summary>
-    /// The filter every caller shares: workflow state, date range, survey, the
-    /// optional filter question/answer pair, and the measured question.
+    /// An answer value counts only when NEITHER it NOR the answer owning it has
+    /// been soft-deleted.
     ///
-    /// Note this deliberately does NOT filter Answer.WorkflowState - the charts
-    /// never have, and adding it here would silently change every chart. The raw
-    /// data table applies it separately in BuildAnswerQuery.
+    /// Both halves are needed. Charts historically checked only the value, which
+    /// let an answer whose parent row was marked removed keep contributing to
+    /// every chart while the raw data table excluded it - the two disagreed by
+    /// four answers on a real dashboard. Expressing the rule once, here, means
+    /// there is no longer a place to check one half and forget the other.
+    /// </summary>
+    public static IQueryable<AnswerValue> WhereAnswerIsLive(IQueryable<AnswerValue> answerValues) =>
+        answerValues
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => x.Answer.WorkflowState != Constants.WorkflowStates.Removed);
+
+    /// <summary>
+    /// The filter every caller shares: liveness, date range, survey, the optional
+    /// filter question/answer pair, and the measured question.
     /// </summary>
     public static IQueryable<AnswerValue> BuildFilteredAnswerValues(
         MicrotingDbContext sdkContext,
@@ -65,10 +76,7 @@ public static class AnswerFilterHelper
         // Includes is a translation hazard; BuildAnswerQuery would inherit the
         // same problem. The chart callers attach their own Includes to the
         // returned query, exactly as they did before this was extracted.
-        var answerQueryable = sdkContext.AnswerValues
-            .AsNoTracking()
-            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-            .AsQueryable();
+        var answerQueryable = WhereAnswerIsLive(sdkContext.AnswerValues.AsNoTracking());
 
         if (answerDates.Today)
         {
@@ -163,11 +171,8 @@ public static class AnswerFilterHelper
             : answerQueryable.Where(x => !ignoredOptionIds.Contains(x.OptionId));
 
     /// <summary>
-    /// The answers behind one dashboard item, for the raw data table.
-    ///
-    /// Adds Answer.WorkflowState filtering on top of the shared filter. The delete
-    /// path sets that alongside AnswerValue.WorkflowState, so this does not change
-    /// counts in practice.
+    /// The answers behind one dashboard item, for the raw data table. Selects from
+    /// the same shared filter the charts use, so the two cannot disagree.
     /// </summary>
     public static IQueryable<Answer> BuildAnswerQuery(
         MicrotingDbContext sdkContext,
@@ -178,8 +183,7 @@ public static class AnswerFilterHelper
         DashboardEditAnswerDates answerDates)
     {
         var answerValues = BuildFilteredAnswerValues(
-                sdkContext, dashboardItem, dashboardSurveyId, answerDates)
-            .Where(x => x.Answer.WorkflowState != Constants.WorkflowStates.Removed);
+            sdkContext, dashboardItem, dashboardSurveyId, answerDates);
 
         if (!dashboardItem.CompareEnabled)
         {


### PR DESCRIPTION
Dashboard 9's first chart reported **57** answers while the raw data table under it reported **53**.

## Cause

Four answers have `Answers.WorkflowState = 'removed'` while their `AnswerValues` are still `'created'`. Charts filtered only the value's workflow state and counted them; the raw data table also filtered the answer's and did not.

That divergence arrived with the raw data table (#1502) and was justified in a comment claiming the delete path sets both states together, so the extra filter *"does not change counts in practice"*. This dashboard disproves it.

## Fix

One predicate, applied everywhere:

```csharp
public static IQueryable<AnswerValue> WhereAnswerIsLive(IQueryable<AnswerValue> answerValues) =>
    answerValues
        .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
        .Where(x => x.Answer.WorkflowState != Constants.WorkflowStates.Removed);
```

`BuildFilteredAnswerValues` applies it, so both `Calculate` methods and the raw data table inherit the same definition. There is no longer a place to check one half and forget the other. The two comments asserting the split was safe are removed.

## ⚠ This changes reported numbers

Soft-deleted answers stop contributing to **charts, chart data tables, Word exports and the interviews export**.

In the live dev database that is **10 answers on one survey (1.6% of it)**, visible on dashboards **3, 8, 9, 10, 11**. Dashboard 9's first chart moves 57 → 53, matching its raw table. Verified in the browser after restarting the API — the chart's Total and `Rådata — 53 svar` now agree.

## Where those rows came from — not this application

Worth recording, because it decides whether the count regrows:

- `AnswersService` deletes an answer's **values first**, then the answer, so a half-completed delete leaves the *opposite* state.
- `PnBase.Delete` bumps `Version` and writes an `AnswerVersions` row. All 12 removed answers sit at `Version = 1` with `UpdatedAt == CreatedAt`, and there is **not one** `AnswerVersions` row marked removed.
- Each has a unique `MicrotingUid`, so they are not re-import duplicates.

They were set by direct SQL bypassing the entity layer. If that keeps happening, the count grows again.

## Regression test

`RemovedAnswerWithLiveValues_IsExcludedFromChartsAndRawDataAlike` reproduces the state exactly — raw SQL marks one answer removed while leaving its values live, because `PnBase.Delete` would remove the values too and destroy the case under test — then asserts the chart path and the raw path select the same answers and both exclude it. It restores the row in a `finally` and asserts the restore worked, since the suite shares a database.

Verified locally both ways: it **fails** against the previous behaviour and **passes** against this one. The seeded `420_SDK.sql` contains zero `'removed'` rows, so without a test that creates the state this bug is untestable by construction — and the golden `ChartDataUTests` fixtures are unaffected for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnP42zmHAgo2NZQsa6zdhG