### PR TITLE
fix: hide soft-deleted answers from the answer detail lookup

### DIFF
--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswersUTests.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswersUTests.cs
@@ -197,13 +197,13 @@ public class AnswersUTests : DbTestFixture
         Assert.That(before?.AnswerValues, Is.Not.Empty,
             "The chosen answer must have values, or this proves nothing.");
 
-        var valueId = await DbContext.AnswerValues
-            .AsNoTracking()
-            .Where(x => x.AnswerId == subject.Id)
-            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-            .OrderBy(x => x.Id)
-            .Select(x => x.Id)
-            .FirstAsync();
+        // Taken from the lookup's own output rather than from AnswerValues
+        // directly. The lookup inner-joins QuestionTranslations on
+        // value.QuestionId == translation.Id - which is a known defect, see the
+        // note on GetAnswerQueryByMicrotingUid - so a value picked straight from
+        // the table may not be visible to it, and the count assertion below would
+        // then fail for a reason unrelated to workflow state.
+        var valueId = before.AnswerValues.OrderBy(x => x.Id).First().Id;
 
         var strategy = DbContext.Database.CreateExecutionStrategy();
 
@@ -252,6 +252,11 @@ public class AnswersUTests : DbTestFixture
             .Where(x => DbContext.Sites.Any(s => s.Id == x.SiteId))
             .Where(x => DbContext.AnswerValues.Any(v =>
                 v.AnswerId == x.Id && v.WorkflowState != Constants.WorkflowStates.Removed))
+            // The lookup matches on MicrotingUid and takes the first row. There is
+            // no unique index on that column, so a shared uid would let a sibling
+            // answer satisfy the query after this one is marked removed, and the
+            // "is null" assertion would fail for the wrong reason.
+            .Where(x => DbContext.Answers.Count(y => y.MicrotingUid == x.MicrotingUid) == 1)
             .OrderBy(x => x.Id)
             .Select(x => new AnswerSubject { Id = x.Id, MicrotingUid = (int)x.MicrotingUid })
             .FirstOrDefaultAsync();

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswersUTests.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswersUTests.cs
@@ -120,4 +120,146 @@ public class AnswersUTests : DbTestFixture
 
         await DbContext.SaveChangesAsync();
     }
+
+    /// <summary>
+    /// The answer detail lookup used to have its workflow-state filters commented
+    /// out, so a soft-deleted answer was still returned and rendered as though it
+    /// were live - AnswerViewModel carries no WorkflowState, so nothing on the page
+    /// marked it. Charts and the raw data table already excluded such answers, which
+    /// left this the last inconsistent reader.
+    ///
+    /// Runs inside a transaction that is never committed, so the shared test
+    /// database is unchanged even if the process dies. MySqlRetryingExecutionStrategy
+    /// refuses user-initiated transactions unless the unit runs through
+    /// CreateExecutionStrategy, hence the wrapper.
+    /// </summary>
+    [Test]
+    public async Task AnswerLookup_ExcludesSoftDeletedAnswer()
+    {
+        var subject = await LiveAnswerVisibleToTheLookup();
+
+        Assert.That(subject, Is.Not.Null,
+            "Seed data has no answer the detail lookup can return.");
+
+        var before = await AnswerHelper
+            .GetAnswerQueryByMicrotingUid(subject.MicrotingUid, DbContext)
+            .FirstOrDefaultAsync();
+
+        Assert.That(before, Is.Not.Null,
+            "The chosen answer must be visible to begin with, or this proves nothing.");
+
+        var strategy = DbContext.Database.CreateExecutionStrategy();
+
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await DbContext.Database.BeginTransactionAsync();
+
+            // Raw SQL, not PnBase.Delete: Delete would also remove the values, and
+            // then the answer-side filter alone could not be what excluded it.
+            await DbContext.Database.ExecuteSqlRawAsync(
+                "UPDATE Answers SET WorkflowState = 'removed' WHERE Id = {0}", subject.Id);
+
+            var after = await AnswerHelper
+                .GetAnswerQueryByMicrotingUid(subject.MicrotingUid, DbContext)
+                .FirstOrDefaultAsync();
+
+            Assert.That(after, Is.Null,
+                "A soft-deleted answer must not be returned by the detail lookup.");
+
+            await transaction.RollbackAsync();
+        });
+
+        var restored = await AnswerHelper
+            .GetAnswerQueryByMicrotingUid(subject.MicrotingUid, DbContext)
+            .FirstOrDefaultAsync();
+
+        Assert.That(restored, Is.Not.Null,
+            "Rollback failed - the shared test database is left modified.");
+    }
+
+    /// <summary>
+    /// The second, independent filter: a live answer must not carry soft-deleted
+    /// values. Separate test because the two filters guard different things and one
+    /// could be re-commented without the other.
+    /// </summary>
+    [Test]
+    public async Task AnswerLookup_ExcludesSoftDeletedValuesOfALiveAnswer()
+    {
+        var subject = await LiveAnswerVisibleToTheLookup();
+
+        Assert.That(subject, Is.Not.Null,
+            "Seed data has no answer the detail lookup can return.");
+
+        var before = await AnswerHelper
+            .GetAnswerQueryByMicrotingUid(subject.MicrotingUid, DbContext)
+            .FirstOrDefaultAsync();
+
+        Assert.That(before?.AnswerValues, Is.Not.Empty,
+            "The chosen answer must have values, or this proves nothing.");
+
+        var valueId = await DbContext.AnswerValues
+            .AsNoTracking()
+            .Where(x => x.AnswerId == subject.Id)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .FirstAsync();
+
+        var strategy = DbContext.Database.CreateExecutionStrategy();
+
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await DbContext.Database.BeginTransactionAsync();
+
+            await DbContext.Database.ExecuteSqlRawAsync(
+                "UPDATE AnswerValues SET WorkflowState = 'removed' WHERE Id = {0}", valueId);
+
+            var after = await AnswerHelper
+                .GetAnswerQueryByMicrotingUid(subject.MicrotingUid, DbContext)
+                .FirstOrDefaultAsync();
+
+            Assert.That(after, Is.Not.Null,
+                "The answer itself is still live and must still be returned.");
+            Assert.That(after.AnswerValues.Count, Is.EqualTo(before.AnswerValues.Count - 1),
+                "Exactly the soft-deleted value should have dropped out.");
+            Assert.That(after.AnswerValues.Select(x => x.Id), Does.Not.Contain(valueId));
+
+            await transaction.RollbackAsync();
+        });
+
+        var restored = await AnswerHelper
+            .GetAnswerQueryByMicrotingUid(subject.MicrotingUid, DbContext)
+            .FirstOrDefaultAsync();
+
+        Assert.That(restored?.AnswerValues.Count, Is.EqualTo(before.AnswerValues.Count),
+            "Rollback failed - the shared test database is left modified.");
+    }
+
+    /// <summary>
+    /// Picks an answer the detail lookup can actually return. That query inner-joins
+    /// Sites and Units, so an answer with a null UnitId is invisible to it regardless
+    /// of workflow state, and choosing one would make the tests above fail for the
+    /// wrong reason. Ordered so the choice is deterministic rather than left to the
+    /// storage engine.
+    /// </summary>
+    private async Task<AnswerSubject> LiveAnswerVisibleToTheLookup() =>
+        await DbContext.Answers
+            .AsNoTracking()
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => x.MicrotingUid != null)
+            .Where(x => x.UnitId != null)
+            .Where(x => DbContext.Units.Any(u => u.Id == x.UnitId))
+            .Where(x => DbContext.Sites.Any(s => s.Id == x.SiteId))
+            .Where(x => DbContext.AnswerValues.Any(v =>
+                v.AnswerId == x.Id && v.WorkflowState != Constants.WorkflowStates.Removed))
+            .OrderBy(x => x.Id)
+            .Select(x => new AnswerSubject { Id = x.Id, MicrotingUid = (int)x.MicrotingUid })
+            .FirstOrDefaultAsync();
+
+    private sealed class AnswerSubject
+    {
+        public int Id { get; init; }
+
+        public int MicrotingUid { get; init; }
+    }
 }

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Helpers/AnswerHelper.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Helpers/AnswerHelper.cs
@@ -34,6 +34,21 @@ using Microting.eForm.Infrastructure.Data.Entities;
 
 public class AnswerHelper
 {
+    /// <summary>
+    /// Looks up one answer for display. Soft-deleted answers, and soft-deleted
+    /// values belonging to a live answer, are excluded - the same rule
+    /// AnswerFilterHelper.WhereAnswerIsLive applies to the charts and the raw
+    /// data table.
+    ///
+    /// Both filters were previously commented out, so a deleted answer was still
+    /// returned and rendered as though it were live. Nothing marked it: neither
+    /// AnswerViewModel nor AnswerValuesViewModel carries WorkflowState, so the
+    /// page had no way to say otherwise.
+    ///
+    /// The two ForDelete queries below deliberately stay unfiltered.
+    /// AnswersService.DeleteAnswerByMicrotingUid has to be able to fetch an
+    /// already-removed answer in order to report that it is already removed.
+    /// </summary>
     public static IQueryable<AnswerViewModel> GetAnswerQueryByMicrotingUid(int microtingUid,
         MicrotingDbContext dbContext)
     {
@@ -63,7 +78,7 @@ public class AnswerHelper
                     answer.Name,
                     UnitUid = unit.MicrotingUid
                 })
-            //.Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
             .Where(x => x.MicrotingUid == microtingUid)
             .AsQueryable()
             .Select(answers => new AnswerViewModel()
@@ -87,7 +102,7 @@ public class AnswerHelper
                             questionTranslation.Name
                         })
                     .Where(answerValues => answerValues.AnswerId == answers.Id)
-                    //.Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
                     .AsQueryable()
                     .Select(a => new AnswerValuesViewModel()
                     {

--- a/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/01-insight-dashboard-answers.view.spec.ts
+++ b/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/01-insight-dashboard-answers.view.spec.ts
@@ -24,7 +24,11 @@ test.describe('InSight Dashboard - Answers - View', () => {
     await page.close();
   });
 
-  test('should be displayed 18 answers values', async () => {
+  // Numbered so this runs before the delete spec. It needs the answer to still
+  // exist: the lookup now hides soft-deleted answers, so viewing one the delete
+  // spec has removed would find nothing. Previously the order did not matter,
+  // because a deleted answer was still returned.
+  test('should display the answer values of a live answer', async () => {
     await answersPage.searchAnswerByMicrotingUId(microtingUId.toString());
     expect(await answersPage.rowNum()).toBe(19);
   });

--- a/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/02-insight-dashboard-answers.delete.spec.ts
+++ b/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/02-insight-dashboard-answers.delete.spec.ts
@@ -28,6 +28,13 @@ test.describe('InSight Dashboard - Answers - Delete', () => {
     await answersPage.searchAnswerByMicrotingUId(microtingUId.toString());
     await answersPage.deleteAnswer();
     await answersPage.searchAnswerByMicrotingUId(microtingUId.toString());
-    expect(await answersPage.rowNum()).toBe(19);
+
+    // A deleted answer must disappear from the lookup. This asserted 0 when the
+    // spec was written; it was changed to 19 three hours after the lookup's
+    // workflow-state filters were commented out, which turned the regression into
+    // the expected result. The filters are back, so this goes back to 0.
+    // mtx-grid renders its empty state as a div outside the table, so no row
+    // remains in tbody.
+    expect(await answersPage.rowNum()).toBe(0);
   });
 });


### PR DESCRIPTION
Follow-up to #1506, which aligned the charts and the raw data table on a single liveness rule. `AnswerHelper` was the last reader that disagreed.

`GetAnswerQueryByMicrotingUid` had **both** workflow-state filters commented out, so searching a deleted answer's Microting UID returned it and rendered it as though it were live.

Worth being explicit about why that isn't a feature: **nothing marked it as deleted.** Neither `AnswerViewModel` nor `AnswerValuesViewModel` carries `WorkflowState`, the Angular `AnswerModel` has no such field, and no template in the answers page mentions it. I checked the 2021 commit that commented the filters out (`e3cfc91`) on the suspicion it was deliberate — it touched those view models, but not to expose workflow state. So the page was showing deleted data as current, with no signal.

## Change

Both filters enabled — the answer, and the values of a live answer — matching `AnswerFilterHelper.WhereAnswerIsLive`.

The two `ForDelete` queries are **deliberately left unfiltered**, and now say so. `DeleteAnswerByMicrotingUid` (`AnswersService.cs:104,117`) must be able to fetch an already-removed answer to report that it is already removed; filtering them would turn that message into a spurious "not found".

## Tests

Two, one per filter, because they guard different things and one could be re-commented without the other:

- `AnswerLookup_ExcludesSoftDeletedAnswer`
- `AnswerLookup_ExcludesSoftDeletedValuesOfALiveAnswer`

Each constructs its state with raw SQL — `PnBase.Delete` would remove the values too, and then the answer-side filter alone couldn't be shown to be what excluded it — and runs inside a transaction that is never committed, so the shared test database is unchanged even if the process dies.

**Verified by mutation, not just by passing:** re-commenting the answer filter fails the answer test alone; re-commenting the value filter fails the value test alone. Database byte-identical afterwards.

The subject is chosen deterministically and, importantly, only from answers the lookup can actually return — that query inner-joins `Sites` and `Units`, so an answer with a null `UnitId` is invisible to it regardless of workflow state and would fail the test for the wrong reason.

## Note on local runs

`Answer_Get` and `Delete_Answer` fail on my machine because MicrotingUid `1413005` does not exist in my local database (dev data, survey 2 — not the CI seed). Neither is caused by this change: `Delete_Answer` uses only the untouched `ForDelete` queries, and `Answer_Get` looks up a UID with zero matching rows, so it returns null under any filter. CI has the correct seed.

## Still open in this file, not addressed here

- The value projection joins `AnswerValue.QuestionId` to `QuestionTranslation.Id` instead of `.QuestionId`, so the **Question label is wrong**.
- The inner joins on `Sites` and `Units` drop any answer with a null `UnitId`.

Both predate this change and concern the correctness of the projection rather than liveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnP42zmHAgo2NZQsa6zdhG