### PR TITLE
fix: correct the question text and missing-unit defects in the answer lookup

### DIFF
--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswersUTests.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswersUTests.cs
@@ -197,12 +197,9 @@ public class AnswersUTests : DbTestFixture
         Assert.That(before?.AnswerValues, Is.Not.Empty,
             "The chosen answer must have values, or this proves nothing.");
 
-        // Taken from the lookup's own output rather than from AnswerValues
-        // directly. The lookup inner-joins QuestionTranslations on
-        // value.QuestionId == translation.Id - which is a known defect, see the
-        // note on GetAnswerQueryByMicrotingUid - so a value picked straight from
-        // the table may not be visible to it, and the count assertion below would
-        // then fail for a reason unrelated to workflow state.
+        // Taken from the lookup's own output rather than from AnswerValues directly,
+        // so the value is guaranteed to be one the lookup returns and the count
+        // assertion below can only move because of workflow state.
         var valueId = before.AnswerValues.OrderBy(x => x.Id).First().Id;
 
         var strategy = DbContext.Database.CreateExecutionStrategy();
@@ -236,11 +233,14 @@ public class AnswersUTests : DbTestFixture
     }
 
     /// <summary>
-    /// Picks an answer the detail lookup can actually return. That query inner-joins
-    /// Sites and Units, so an answer with a null UnitId is invisible to it regardless
-    /// of workflow state, and choosing one would make the tests above fail for the
-    /// wrong reason. Ordered so the choice is deterministic rather than left to the
-    /// storage engine.
+    /// Picks an answer the detail lookup can actually return, deterministically
+    /// rather than leaving the choice to the storage engine.
+    ///
+    /// The lookup no longer drops answers without a unit, but these tests still
+    /// require one: AnswerLookup_ReturnsAnswersThatHaveNoUnit removes the unit and
+    /// then asserts on the restore, which is only meaningful if there was a unit
+    /// uid to restore. Hence the Units predicate, including its MicrotingUid being
+    /// set - Unit.MicrotingUid is itself nullable.
     /// </summary>
     private async Task<AnswerSubject> LiveAnswerVisibleToTheLookup() =>
         await DbContext.Answers
@@ -248,7 +248,7 @@ public class AnswersUTests : DbTestFixture
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
             .Where(x => x.MicrotingUid != null)
             .Where(x => x.UnitId != null)
-            .Where(x => DbContext.Units.Any(u => u.Id == x.UnitId))
+            .Where(x => DbContext.Units.Any(u => u.Id == x.UnitId && u.MicrotingUid != null))
             .Where(x => DbContext.Sites.Any(s => s.Id == x.SiteId))
             .Where(x => DbContext.AnswerValues.Any(v =>
                 v.AnswerId == x.Id && v.WorkflowState != Constants.WorkflowStates.Removed))
@@ -282,13 +282,15 @@ public class AnswersUTests : DbTestFixture
         var subject = await LiveAnswerVisibleToTheLookup();
         Assert.That(subject, Is.Not.Null, "Seed data has no answer the lookup can return.");
 
-        var questionId = await DbContext.AnswerValues
+        var value = await DbContext.AnswerValues
             .AsNoTracking()
             .Where(x => x.AnswerId == subject.Id)
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
             .OrderBy(x => x.Id)
-            .Select(x => x.QuestionId)
+            .Select(x => new { x.Id, x.QuestionId })
             .FirstAsync();
+
+        var questionId = value.QuestionId;
 
         // The row the broken join would read, and the language to reuse.
         var displaced = await DbContext.QuestionTranslations
@@ -336,14 +338,19 @@ public class AnswersUTests : DbTestFixture
 
             Assert.That(answer, Is.Not.Null);
 
-            var questions = answer.AnswerValues.Select(x => x.Question).ToList();
+            // Scoped to the one value whose question was displaced. Asserting across
+            // the whole answer would be self-defeating: the displaced translation is
+            // moved onto another real question, and on the seeded data that question
+            // belongs to this same answer, so its name legitimately reappears on a
+            // different row.
+            var displacedValue = answer.AnswerValues.Single(x => x.Id == value.Id);
 
-            Assert.That(questions, Does.Contain(marker),
+            Assert.That(displacedValue.Question, Is.EqualTo(marker),
                 "The question text must come from the translation whose QuestionId "
                 + "matches the value, not from the one whose Id happens to.");
-            Assert.That(questions, Does.Not.Contain(displaced.Name),
-                "The displaced translation describes a different question now and must "
-                + "not be shown.");
+            Assert.That(displacedValue.Question, Is.Not.EqualTo(displaced.Name),
+                "Reading the displaced translation means the lookup is still matching "
+                + "on QuestionTranslation.Id.");
 
             await transaction.RollbackAsync();
         });

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswersUTests.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/AnswersUTests.cs
@@ -261,6 +261,144 @@ public class AnswersUTests : DbTestFixture
             .Select(x => new AnswerSubject { Id = x.Id, MicrotingUid = (int)x.MicrotingUid })
             .FirstOrDefaultAsync();
 
+    /// <summary>
+    /// The lookup used to read the question text by joining AnswerValue.QuestionId
+    /// to QuestionTranslation.Id - two different keys - so the label was whichever
+    /// translation happened to share that number, and values with no such row
+    /// vanished entirely.
+    ///
+    /// The seeded database cannot expose this: every QuestionTranslation there has
+    /// Id equal to its QuestionId, so the wrong join coincidentally agrees with the
+    /// right one. The test therefore builds the divergence itself - it points the
+    /// row whose Id matches the question at a different question, and gives the
+    /// question a translation with a distinctive name. A correct lookup reads the
+    /// distinctive name; the old join reads the displaced row.
+    /// </summary>
+    [Test]
+    public async Task AnswerLookup_ReadsQuestionTextByQuestionIdNotByTranslationId()
+    {
+        const string marker = "CORRECT-JOIN-MARKER";
+
+        var subject = await LiveAnswerVisibleToTheLookup();
+        Assert.That(subject, Is.Not.Null, "Seed data has no answer the lookup can return.");
+
+        var questionId = await DbContext.AnswerValues
+            .AsNoTracking()
+            .Where(x => x.AnswerId == subject.Id)
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .OrderBy(x => x.Id)
+            .Select(x => x.QuestionId)
+            .FirstAsync();
+
+        // The row the broken join would read, and the language to reuse.
+        var displaced = await DbContext.QuestionTranslations
+            .AsNoTracking()
+            .Where(x => x.Id == questionId)
+            .Select(x => new { x.Id, x.LanguageId, x.Name })
+            .FirstOrDefaultAsync();
+
+        Assert.That(displaced, Is.Not.Null,
+            "Expected the seed's Id == QuestionId shape; without it this test cannot "
+            + "distinguish the two joins.");
+
+        // QuestionTranslations.QuestionId is a foreign key, so the displaced row has
+        // to point at a real question - just not this one.
+        var otherQuestionId = await DbContext.Questions
+            .AsNoTracking()
+            .Where(x => x.Id != questionId)
+            .OrderBy(x => x.Id)
+            .Select(x => x.Id)
+            .FirstOrDefaultAsync();
+
+        Assert.That(otherQuestionId, Is.GreaterThan(0),
+            "Need a second question to displace the translation onto.");
+
+        var strategy = DbContext.Database.CreateExecutionStrategy();
+
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await DbContext.Database.BeginTransactionAsync();
+
+            // Break the coincidence: the row whose Id == questionId now describes a
+            // different question, so only a QuestionId match can find the real text.
+            await DbContext.Database.ExecuteSqlRawAsync(
+                "UPDATE QuestionTranslations SET QuestionId = {0} WHERE Id = {1}",
+                otherQuestionId, displaced.Id);
+
+            await DbContext.Database.ExecuteSqlRawAsync(
+                "INSERT INTO QuestionTranslations (Version, WorkflowState, CreatedAt, UpdatedAt, "
+                + "QuestionId, LanguageId, Name) VALUES (1, 'created', NOW(), NOW(), {0}, {1}, {2})",
+                questionId, displaced.LanguageId, marker);
+
+            var answer = await AnswerHelper
+                .GetAnswerQueryByMicrotingUid(subject.MicrotingUid, DbContext)
+                .FirstOrDefaultAsync();
+
+            Assert.That(answer, Is.Not.Null);
+
+            var questions = answer.AnswerValues.Select(x => x.Question).ToList();
+
+            Assert.That(questions, Does.Contain(marker),
+                "The question text must come from the translation whose QuestionId "
+                + "matches the value, not from the one whose Id happens to.");
+            Assert.That(questions, Does.Not.Contain(displaced.Name),
+                "The displaced translation describes a different question now and must "
+                + "not be shown.");
+
+            await transaction.RollbackAsync();
+        });
+
+        var afterRollback = await DbContext.QuestionTranslations
+            .AsNoTracking()
+            .Where(x => x.Id == displaced.Id)
+            .Select(x => x.QuestionId)
+            .FirstAsync();
+
+        Assert.That(afterRollback, Is.EqualTo(questionId),
+            "Rollback failed - the shared test database is left modified.");
+    }
+
+    /// <summary>
+    /// Answer.UnitId is nullable, but the lookup inner-joined Units, so an answer
+    /// without a unit was dropped and the endpoint reported it as not found - the
+    /// same message it gives for an answer that genuinely does not exist.
+    /// </summary>
+    [Test]
+    public async Task AnswerLookup_ReturnsAnswersThatHaveNoUnit()
+    {
+        var subject = await LiveAnswerVisibleToTheLookup();
+        Assert.That(subject, Is.Not.Null, "Seed data has no answer the lookup can return.");
+
+        var strategy = DbContext.Database.CreateExecutionStrategy();
+
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var transaction = await DbContext.Database.BeginTransactionAsync();
+
+            await DbContext.Database.ExecuteSqlRawAsync(
+                "UPDATE Answers SET UnitId = NULL WHERE Id = {0}", subject.Id);
+
+            var answer = await AnswerHelper
+                .GetAnswerQueryByMicrotingUid(subject.MicrotingUid, DbContext)
+                .FirstOrDefaultAsync();
+
+            Assert.That(answer, Is.Not.Null,
+                "An answer with no unit must still be returned, not reported as missing.");
+            Assert.That(answer.UnitId, Is.Null, "With no unit there is no unit uid to show.");
+            Assert.That(answer.AnswerValues, Is.Not.Empty,
+                "Its values must still come back.");
+
+            await transaction.RollbackAsync();
+        });
+
+        var restored = await AnswerHelper
+            .GetAnswerQueryByMicrotingUid(subject.MicrotingUid, DbContext)
+            .FirstOrDefaultAsync();
+
+        Assert.That(restored?.UnitId, Is.Not.Null,
+            "Rollback failed - the shared test database is left modified.");
+    }
+
     private sealed class AnswerSubject
     {
         public int Id { get; init; }

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Helpers/AnswerHelper.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Helpers/AnswerHelper.cs
@@ -45,6 +45,10 @@ public class AnswerHelper
     /// AnswerViewModel nor AnswerValuesViewModel carries WorkflowState, so the
     /// page had no way to say otherwise.
     ///
+    /// The answer's unit is optional, so an answer without one comes back with
+    /// UnitId null instead of being dropped, and the question text is resolved
+    /// through QuestionTranslation.QuestionId.
+    ///
     /// The two ForDelete queries below deliberately stay unfiltered.
     /// AnswersService.DeleteAnswerByMicrotingUid has to be able to fetch an
     /// already-removed answer in order to report that it is already removed.
@@ -83,6 +87,14 @@ public class AnswerHelper
                         // real relationship; taking the first non-removed translation
                         // keeps one row per value, which a corrected join would not
                         // once a question has more than one language.
+                        //
+                        // TODO: lowest Id is insertion order, not a language choice.
+                        // On a multi-language survey this can pair a question in one
+                        // language with an option value in another, on the same row -
+                        // the grid shows the option's language in its own column.
+                        // RawDataTranslations.GetPreferredLanguageIdsAsync already
+                        // resolves this properly (user language, then the survey's,
+                        // then anything live) and should be threaded in here.
                         Question = dbContext.QuestionTranslations
                             .Where(translation => translation.QuestionId == value.QuestionId)
                             .Where(translation =>

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Helpers/AnswerHelper.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Helpers/AnswerHelper.cs
@@ -52,66 +52,46 @@ public class AnswerHelper
     public static IQueryable<AnswerViewModel> GetAnswerQueryByMicrotingUid(int microtingUid,
         MicrotingDbContext dbContext)
     {
-        var answersQueryable = dbContext.Answers.Join(dbContext.Sites,
-                answer => answer.SiteId,
-                site => site.Id,
-                (newAnswer, site) => new
-                {
-                    newAnswer.WorkflowState,
-                    newAnswer.MicrotingUid,
-                    newAnswer.UnitId,
-                    newAnswer.FinishedAt,
-                    newAnswer.AnswerDuration,
-                    newAnswer.Id,
-                    site.Name
-                }).Join(dbContext.Units,
-                answer => answer.UnitId,
-                unit => unit.Id,
-                (answer, unit) => new
-                {
-                    answer.WorkflowState,
-                    answer.MicrotingUid,
-                    answer.Id,
-                    answer.UnitId,
-                    answer.FinishedAt,
-                    answer.AnswerDuration,
-                    answer.Name,
-                    UnitUid = unit.MicrotingUid
-                })
+        // Navigations rather than explicit joins. Answer.Unit is optional, so EF
+        // emits a LEFT JOIN and an answer with no unit is still returned; the
+        // previous inner join silently dropped those answers, which surfaced as an
+        // indistinguishable "answer not found".
+        var answersQueryable = dbContext.Answers
+            .AsNoTracking()
             .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
             .Where(x => x.MicrotingUid == microtingUid)
-            .AsQueryable()
-            .Select(answers => new AnswerViewModel()
+            .Select(answer => new AnswerViewModel()
             {
-                Id = answers.Id,
-                MicrotingUid = (int)answers.MicrotingUid,
-                UnitId = (int)answers.UnitUid,
-                FinishedAt = answers.FinishedAt,
-                AnswerDuration = answers.AnswerDuration,
-                SiteName = answers.Name,
-                AnswerValues = dbContext.AnswerValues.Join(dbContext.QuestionTranslations,
-                        value => value.QuestionId,
-                        questionTranslation => questionTranslation.Id,
-                        (value, questionTranslation) => new
-                        {
-                            value.AnswerId,
-                            value.WorkflowState,
-                            value.Value,
-                            value.Id,
-                            value.OptionId,
-                            questionTranslation.Name
-                        })
-                    .Where(answerValues => answerValues.AnswerId == answers.Id)
-                    .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
-                    .AsQueryable()
-                    .Select(a => new AnswerValuesViewModel()
+                Id = answer.Id,
+                MicrotingUid = (int)answer.MicrotingUid,
+                UnitId = answer.Unit.MicrotingUid,
+                FinishedAt = answer.FinishedAt,
+                AnswerDuration = answer.AnswerDuration,
+                SiteName = answer.Site.Name,
+                AnswerValues = dbContext.AnswerValues
+                    .Where(value => value.AnswerId == answer.Id)
+                    .Where(value => value.WorkflowState != Constants.WorkflowStates.Removed)
+                    .Select(value => new AnswerValuesViewModel()
                     {
-                        Value = a.Value,
-                        Id = a.Id,
-                        Question = a.Name,
+                        Value = value.Value,
+                        Id = value.Id,
+                        // Correlated lookup instead of a join. The join here matched
+                        // AnswerValue.QuestionId against QuestionTranslation.Id - a
+                        // different key - so the question text was whichever
+                        // translation happened to share that number. It also dropped
+                        // any value with no such row. Matching on QuestionId is the
+                        // real relationship; taking the first non-removed translation
+                        // keeps one row per value, which a corrected join would not
+                        // once a question has more than one language.
+                        Question = dbContext.QuestionTranslations
+                            .Where(translation => translation.QuestionId == value.QuestionId)
+                            .Where(translation =>
+                                translation.WorkflowState != Constants.WorkflowStates.Removed)
+                            .OrderBy(translation => translation.Id)
+                            .Select(translation => translation.Name)
+                            .FirstOrDefault(),
                         Translations = dbContext.OptionTranslations
-                            .Where(x => x.OptionId == a.OptionId)
-                            .AsQueryable()
+                            .Where(x => x.OptionId == value.OptionId)
                             .Select(translations => new AnswerValueTranslationModel()
                             {
                                 Value = translations.Name,

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Models/Answers/AnswerViewModel.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Models/Answers/AnswerViewModel.cs
@@ -32,7 +32,12 @@ public class AnswerViewModel
 {
     public int Id { get; set; }
     public int MicrotingUid { get; set; }
-    public int UnitId { get; set; }
+    /// <summary>
+    /// The unit's Microting UID, or null when the answer has no unit. Answer.UnitId
+    /// is nullable, and such answers used to be dropped entirely by an inner join
+    /// rather than shown with the unit blank.
+    /// </summary>
+    public int? UnitId { get; set; }
     public DateTime FinishedAt { get; set; }
     public int AnswerDuration { get; set; }
     public string SiteName { get; set; }

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/models/answer/answer.model.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/models/answer/answer.model.ts
@@ -4,7 +4,10 @@ export class AnswerModel {
   finishedAt: string;
   answerDuration: number;
   siteName: string;
-  unitId: number;  answerValues: AnswerValuesModel[] = [];
+  // Null when the answer has no unit. This could not be null before, because such
+  // answers were dropped by an inner join and never reached the client at all.
+  unitId: number | null;
+  answerValues: AnswerValuesModel[] = [];
 }
 
 export class AnswerValuesModel {


### PR DESCRIPTION
The two defects left open by #1507, each now with a test.

## 1. The question label came from the wrong row

`GetAnswerQueryByMicrotingUid` joined `AnswerValue.QuestionId` to `QuestionTranslation.**Id**` — two different keys. The text shown was whichever translation happened to carry that number as its primary key, and any value with no such row **disappeared from the answer entirely**.

Now matched on `QuestionTranslation.QuestionId`, expressed as a correlated lookup rather than a join. A corrected *join* would multiply rows the moment a question has more than one language, so it takes the first non-removed translation.

## 2. Answers with no unit were reported as "not found"

`Answer.UnitId` is nullable, but the query inner-joined `Units`, so those answers were dropped — surfacing as the same "not found" message an answer that never existed gets. **48 of ~600** answers in the local dev database are in that state.

The explicit joins on `Sites`/`Units` are replaced by the navigation properties, so `Unit` becomes a `LEFT JOIN`. `AnswerViewModel.UnitId` becomes `int?` and the Angular model follows — it could not be null before, because such answers never reached the client.

## Why both needed constructed state

**Neither bug is observable in the seeded database.** Every `QuestionTranslation` in `420_SDK.sql` has `Id` equal to its `QuestionId`, so the wrong join coincidentally agrees with the right one; and the answers the e2e specs use all have units. A test written against seed data as-is would pass either way.

So each test builds what it needs, inside a transaction that is never committed:

- `AnswerLookup_ReadsQuestionTextByQuestionIdNotByTranslationId` displaces the translation whose `Id` matches the question onto a *different* question (it's an FK, so it must point at a real one) and gives the real question a distinctively named translation. A correct lookup reads the marker; the old join reads the displaced row.
- `AnswerLookup_ReturnsAnswersThatHaveNoUnit` nulls an answer's `UnitId` and asserts it is still returned, with `UnitId` null and its values intact.

**Verified by mutation, not just by passing:** restoring the `Id` join fails *only* the question-text test; restoring the inner-join behaviour fails *only* the missing-unit test. Database byte-identical afterwards, confirmed including a check for leaked rows.

## e2e impact: none

The rewrite no longer drops values that lack a question translation, so the rendered row count could in principle move. It does not: for the answer the specs use, all 19 live values have translations under both the old and new join. Verified by loading `420_SDK.sql` into a scratch database and counting what the new query returns — still 19.

## Note on local runs

`Answer_Get` and `Delete_Answer` fail on my machine, as they did before this change, because MicrotingUid `1413005` does not exist in my local database (dev data, not the CI seed). Both passed in CI on #1507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnP42zmHAgo2NZQsa6zdhG