### PR TITLE
feat: export every dashboard table as tab separated CSV

### DIFF
--- a/docs/superpowers/specs/2026-08-06-dashboard-table-csv-export-design.md
+++ b/docs/superpowers/specs/2026-08-06-dashboard-table-csv-export-design.md
@@ -1,0 +1,289 @@
+# Tab-separated CSV export for every Insight Dashboard table
+
+Date: 2026-08-06
+Status: design approved
+
+## Problem
+
+A dashboard view renders up to three tables per item and none of them can be
+copied out as a data file:
+
+| Table | Component | Data source | Export today |
+|---|---|---|---|
+| Aggregated chart data | `DashboardChartDataViewComponent` | `itemModel.chartData.rawData`, already in the browser | none |
+| Raw data | `DashboardRawDataViewComponent` | server-paged endpoint, 25 rows in the browser | server-side `.xlsx` |
+| Interviews | `DashboardInterviewsViewComponent` | `itemModel.textQuestionData`, already in the browser | a commented-out button calling a server-side `.xlsx` endpoint |
+
+Users need every table as a delimited text file they can open in Excel.
+
+## Scope
+
+Plugin repo only: `eform-angular-insight-dashboard-plugin`.
+
+No backend change, no `-base` change, no EF migration, no core-frontend change.
+Every export is built and downloaded **in the browser**.
+
+The session is in **base dev mode**, so edits are made inside the host app
+(`eform-angular-frontend/eform-client/src/app/plugins/modules/insight-dashboard-pn`)
+and synced back with `devgetchanges.sh`.
+
+## Format
+
+The file extension is `.csv` and the delimiter is a tab. That contradiction is
+deliberate and requested: users say "CSV", Excel on a Danish locale opens
+tab-delimited text far more reliably than comma-delimited, and a tab almost never
+occurs inside survey text.
+
+- Fields joined by `\t`, records by `\r\n`, trailing `\r\n` after the last record.
+- A field containing a tab, `\r`, `\n` or `"` is wrapped in `"` with internal
+  quotes doubled — RFC 4180 quoting with tab as the delimiter. Every other field
+  is emitted raw, so the common case stays free of quote noise.
+- `null` and `undefined` become the empty string.
+- The payload is prefixed with a UTF-8 BOM (`﻿`). Without it Excel guesses
+  the code page and mangles `æ ø å` in Danish survey text.
+- Blob MIME type `text/tab-separated-values;charset=utf-8`, handed to `saveAs`
+  from `file-saver` — the same download path the plugin's existing `.xlsx`
+  exports use.
+
+### Filenames
+
+`{dashboardName}_{position}_chart_data.csv`, `_raw_data.csv`, `_interviews.csv`,
+where `position` is `itemModel.position`. Characters illegal in a filename
+(`\ / : * ? " < > |`) and control characters are replaced with `_`; an empty or
+all-illegal dashboard name falls back to `dashboard`.
+
+## Architecture
+
+### New: `helpers/tsv-export.helper.ts`
+
+```ts
+export function escapeTsvField(value: unknown): string;
+export function buildTsv(sections: TsvSection[]): string;
+export function tsvFileName(dashboardName: string, position: number, suffix: string): string;
+export function downloadTsv(fileName: string, tsv: string): void;
+```
+
+```ts
+export interface TsvSection {
+  headers?: string[];
+  rows: string[][];
+}
+```
+
+A `TsvSection[]` rather than a single `(headers, rows)` pair because the
+chart-data table is genuinely two stacked tables (percent block, amount block)
+that must stay visually separated in the file. Sections are joined by one blank
+record. A single-section export — raw data, interviews — is just an array of one.
+
+This helper is the only place the delimiter, the quoting rule and the BOM live.
+All three components call it; none of them format anything themselves.
+
+It lives in the plugin, not in `src/app/common/helpers`, because a core-frontend
+helper would mean committing to a second repository for a plugin-only feature.
+
+### Changed components
+
+**`DashboardChartDataViewComponent`**
+
+Gains `@Input() dashboardViewModel` (it currently only receives `itemModel`, and
+the filename needs the dashboard name — `dashboard-block-view.component.html`
+already has both to hand) and an `exportToCsv()` method.
+
+The rendered table has two shapes and the export mirrors both.
+
+*Non grouped chart types.* For each `rawData` block, two sections:
+
+```
+                  <rawHeaders[0]>   <rawHeaders[1]>   …
+<valueName>       82%               74%
+<valueName>       18%               26%
+                                                        <- blank record
+                  <rawHeaders[0]>   <rawHeaders[1]>   …
+<valueName>       41                33
+<valueName>       9                 12
+```
+
+The leading header cell is empty, matching the empty `<th>` above the value-name
+column on screen. Percent cells carry the `%` suffix exactly as displayed, unless
+`itemModel.calculateAverage` is set, in which case the screen shows a bare number
+and so does the file. **The file reproduces the table, including its units.**
+
+*`HorizontalBarStackedGrouped`.* **One** section per block, not two. This chart
+renders percentages and amounts side by side in a single row, under a single
+header row whose `rawHeaders` already name both halves — verified against live
+data, where a six-cell header sits above rows of three percentages followed by
+three amounts. Splitting it would misalign the headers, not fix them. So the
+record is `[rawValueName, valueName, ...percents, ...amounts]` under headers
+`['', '', ...rawHeaders]`, with `rawValueName` promoted from the on-screen
+`rowSpan` cell to a leading column repeated on every row.
+
+When `chartData.rawData` holds several blocks, each block's sections follow the
+previous block's, separated by the same blank record.
+
+`calculateAverage` drops the percent sign in both variants. The grouped template
+appends `%` unconditionally, which is an oversight: writing `4.2%` for an average
+of 4.2 would be actively wrong in a data file, so the export does not reproduce
+it.
+
+**`DashboardRawDataViewComponent`**
+
+Gains `exportToCsv()` beside the existing `exportToExcel()`.
+
+The grid holds one page. The export issues one more call to the same
+`getRawData` endpoint with `offset: 0`, `pageSize: total` and the currently
+active `sort`/`isSortDsc`, then builds the file from that response. No new
+endpoint, and the server-side ordering guarantees the file matches the grid's
+order.
+
+Columns exported are the ones **currently visible in the grid**, i.e.
+`tableHeaders.filter(c => !c.hide)`. `mtx-grid`'s column menu toggles `hide` on
+the objects the component passes in, so the column picker controls the CSV. This
+is a deliberate split from the `.xlsx` export, which keeps exporting every column
+including the hidden ones: the CSV is "what I am looking at", the xlsx is
+"everything".
+
+Header text comes from the already-resolved `MtxGridColumn.header`. For answer
+columns that is a `TranslateService.stream(...)` observable, so the component
+holds the raw `RawDataColumnModel[]` alongside `tableHeaders` and resolves answer
+headers with `translateService.instant(...)` at export time. Question and option
+headers are database text and are used as-is.
+
+The button is disabled while `loading` or when `total === 0`.
+
+Cell values are written exactly as the grid renders them, `Finished at` included
+— which today means a full `Date.toString()`, `Mon Jun 29 2026 20:37:00 GMT+0200
+(Central European Summer Time)`. That is what the grid shows, so that is what the
+file carries. Formatting it is a change to the raw data table, listed as a
+follow-up rather than smuggled in here, because a CSV that disagreed with the
+screen would be worse than an ugly date.
+
+**`DashboardInterviewsViewComponent`**
+
+The commented-out button block is replaced by a working CSV button. Data is
+`itemModel.textQuestionData`, entirely client-side, so the export is a pure
+transform: headers `Date`/`Tag`/`Comments` resolved through
+`translateService.instant`, and one row per entry with `date` formatted
+`dd.MM.y HH:mm:ss` through Angular's `DatePipe` — the same format the grid
+column declares. The button is hidden when there is no data.
+
+The existing `exportToCsv()` method — which despite its name downloads a
+server-side `.xlsx` — is renamed `exportToExcel()` for honesty and left otherwise
+untouched; it has no caller today.
+
+### Buttons and ids
+
+| Table | Placement | Element id |
+|---|---|---|
+| Chart data | icon button in a right-aligned bar above the table | `dashboardChartDataExportCsv{position}` |
+| Raw data | second icon button in the existing `toolbarTpl` | `dashboardRawDataExportCsv{position}` |
+| Interviews | icon button in a right-aligned bar above the grid | `dashboardInterviewsExportCsv{position}` |
+
+All three use `<mat-icon>file_download</mat-icon>` with a `matTooltip` of
+`'Export to CSV' | translate`, matching the existing raw-data export button.
+
+### i18n
+
+One new key in `i18n/en-US.ts` and `i18n/da.ts`:
+
+```
+'Export to CSV': 'Export to CSV'      // en-US
+'Export to CSV': 'Eksportér til CSV'  // da
+```
+
+`Date`, `Tag` and `Comments` already exist — the interviews grid uses them.
+
+## Error handling
+
+| Case | Behaviour |
+|---|---|
+| Chart data has no `rawData` blocks | button not rendered |
+| Interviews has no rows | button not rendered |
+| Raw data `total === 0`, or still loading | button rendered but disabled |
+| Raw data refetch fails or returns `success: false` | no file written, `loading` cleared; the grid's own error surface already covers the request |
+| Dashboard name empty or all-illegal characters | filename falls back to `dashboard_{position}_…` |
+
+There is no row cap on the raw-data CSV. The server-side `.xlsx` export refuses
+above 100 000 rows because it builds an OpenXML document in server memory; the
+CSV is a string built in the browser from a response the same endpoint already
+serves, so the constraint does not transfer.
+
+## Testing
+
+Two layers, both already wired up in this repo.
+
+### Jest unit tests (`npm run test:unit`)
+
+- `helpers/tsv-export.helper.spec.ts` — tab delimiter; CRLF records; BOM present
+  exactly once and only at the start; a field containing a tab / a newline / a
+  quote is quoted and its quotes doubled; a plain field is not quoted; `null` and
+  `undefined` become empty; sections separated by one blank record; filename
+  sanitising and the empty-name fallback.
+- `dashboard-chart-data-view.component.spec.ts` — standard variant emits percent
+  and amount sections with the right headers and `%` suffix; `calculateAverage`
+  drops the suffix; `HorizontalBarStackedGrouped` emits the group column and
+  aligned headers; multiple `rawData` blocks concatenate; button hidden with no
+  data.
+- `dashboard-raw-data-view.component.spec.ts` — export calls `getRawData` with
+  `offset: 0`, `pageSize: total` and the active sort; only non-hidden columns
+  reach the file; answer headers are translated and question headers are not;
+  export is a no-op on `success: false`.
+- `dashboard-interviews-view.component.spec.ts` — header row, date formatting,
+  a comment containing a tab is quoted, button hidden when empty.
+
+Component specs assert on the string handed to the download step rather than on
+the browser download, by spying on the helper's `downloadTsv`.
+
+### Playwright e2e (`playwright/e2e/plugins/insight-dashboard-pn/`)
+
+These live only in the plugin repo — neither `devinstall.sh` nor
+`devgetchanges.sh` touches the `playwright/` tree, so they are authored there
+directly and copied into the host app to run.
+
+New `c/insight-dashboard-csv-export.spec.ts`, following the structure of
+`c/insight-dashboard-raw-data.spec.ts` (one page in `beforeAll`, a dashboard
+built from a new `ChartData/DashboardCsvExport.data.ts`). That data carries a
+`Linje` item and a `Vandret Bjælke Stablet Grupperet` item so both export shapes
+are covered, plus a third item on the survey's text question (id 14, `Enter you
+opinion about the question`) for the interviews table. A text first question
+hides the period and chart type controls, so it is filled through a new
+`fillTextQuestionItem` rather than `fillItem`.
+
+Each test clicks an export button, captures the Playwright download, reads the
+file off disk and asserts against its records:
+
+- BOM present, tab-delimited fields, CRLF records, no stray LF
+- filenames `{dashboard}_{position}_{table}.csv`
+- non grouped chart: sections pair up as percentages then amounts, sharing a
+  header, the first carrying `%` and the second not
+- grouped chart: every section keeps both halves on one row, with the group name
+  in the leading column
+- raw data: one record per answer in the whole result — more than the page on
+  screen — and headers equal to the grid's visible headers, `Tidszone` excluded
+- interviews: three columns and `dd.MM.yyyy HH:mm:ss` dates
+
+New locators are added to `InsightDashboard-DashboardView.page.ts` alongside the
+existing `rawDataExportButton`.
+
+The suite logs in as `admin@admin.com` against the `420_SDK.sql` seed, so it runs
+in CI rather than against a developer's own database.
+
+### Regression guard
+
+The existing raw-data Playwright suite — including its `.xlsx` export test — and
+the existing chart-data assertions in the `*.multi.spec.ts` suites run unchanged.
+The chart-data component gains an input and a button above the table; the
+existing specs locate the table by
+`#dashboardViewChartData{position}_{index}` and its rows by id, none of which
+move.
+
+## Follow-ups, explicitly out of scope
+
+- formatting `Finished at` in the raw data grid, which would also fix its export
+- exporting a whole dashboard (all items, all tables) as one file
+- a user preference for the delimiter
+- exporting the chart itself as an image
+- the `InterviewsExport` `ColCount = 6` defect that drops the `Comments` column
+  from the server-side interviews `.xlsx`
+- the 18 plugin jest suites that fail to compile on the removed
+  `async` import from `@angular/core/testing`; the four suites this change
+  touches were migrated to `waitForAsync`, the rest were left alone

--- a/eform-client/playwright/e2e/plugins/insight-dashboard-pn/ChartData/DashboardCsvExport.data.ts
+++ b/eform-client/playwright/e2e/plugins/insight-dashboard-pn/ChartData/DashboardCsvExport.data.ts
@@ -1,0 +1,41 @@
+import { DashboardTestItemEditModel } from '../InsightDashboard-DashboardEdit.page';
+
+/**
+ * Two chart items, because the aggregated table exports in two shapes: the
+ * stacked grouped chart puts percentages and amounts side by side in one row,
+ * every other chart type stacks them as two tables. The text question item that
+ * produces the interviews table cannot live here - it is filled through
+ * fillTextQuestionItem, which skips the chart controls a text question hides.
+ */
+export const dashboardCsvExportItems: DashboardTestItemEditModel[] = [
+  {
+    firstQuestion: 'Q13',
+    firstQuestionForSelect: '13 - Q13: ...',
+    filterQuestionForSelect: '',
+    filterQuestion: '',
+    filterAnswer: '',
+    period: 'Uge',
+    chartType: 'Linje',
+    calculateAverage: false,
+    ignoredAnswerIds: [],
+    comparedItems: [],
+  },
+  {
+    firstQuestion: 'Q13',
+    firstQuestionForSelect: '13 - Q13: ...',
+    filterQuestionForSelect: '',
+    filterQuestion: '',
+    filterAnswer: '',
+    period: 'Uge',
+    chartType: 'Vandret Bjælke Stablet Grupperet',
+    calculateAverage: false,
+    ignoredAnswerIds: [],
+    comparedItems: [],
+  },
+];
+
+/** Question 14 in the Test-Set survey is the survey's only text question. */
+export const csvExportTextQuestion = {
+  firstQuestion: 'Enter you opinion',
+  firstQuestionForSelect: '14 - Enter you opinion about the question',
+};

--- a/eform-client/playwright/e2e/plugins/insight-dashboard-pn/InsightDashboard-DashboardEdit.page.ts
+++ b/eform-client/playwright/e2e/plugins/insight-dashboard-pn/InsightDashboard-DashboardEdit.page.ts
@@ -132,6 +132,24 @@ export class InsightDashboardDashboardEditPage {
     await selectValueInMtxSelect(this.page, `#editChartType${rowNum}`, itemObject.chartType);
   }
 
+  /**
+   * A text first question hides the period, chart type and ignored-values
+   * controls - the item renders an interviews list rather than a chart - so
+   * filling one stops after the question itself.
+   */
+  async fillTextQuestionItem(
+    rowNum: number,
+    firstQuestion: string,
+    firstQuestionForSelect: string
+  ) {
+    await selectValueInNgSelectorWithSeparateValueAndSearchValue(
+      this.page,
+      `#editFirstQuestion${rowNum}`,
+      firstQuestion,
+      firstQuestionForSelect
+    );
+  }
+
   async generateItems(itemsArray: DashboardTestItemEditModel[]) {
     await this.createFirstItem();
     for (let i = 0; i < itemsArray.length; i++) {

--- a/eform-client/playwright/e2e/plugins/insight-dashboard-pn/InsightDashboard-DashboardView.page.ts
+++ b/eform-client/playwright/e2e/plugins/insight-dashboard-pn/InsightDashboard-DashboardView.page.ts
@@ -201,4 +201,18 @@ export class InsightDashboardDashboardViewPage {
     const match = text?.match(/(\d+)/);
     return match ? Number(match[1]) : null;
   }
+
+  // ---- Tab separated CSV export, one button per table ----
+
+  public chartDataExportCsvButton(rowNum: number) {
+    return this.page.locator(`#dashboardChartDataExportCsv${rowNum + 1}`);
+  }
+
+  public rawDataExportCsvButton(rowNum: number) {
+    return this.page.locator(`#dashboardRawDataExportCsv${rowNum + 1}`);
+  }
+
+  public interviewsExportCsvButton(rowNum: number) {
+    return this.page.locator(`#dashboardInterviewsExportCsv${rowNum + 1}`);
+  }
 }

--- a/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/insight-dashboard-csv-export.spec.ts
+++ b/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/insight-dashboard-csv-export.spec.ts
@@ -1,0 +1,285 @@
+import { expect, test } from '@playwright/test';
+import * as fs from 'fs';
+import { LoginPage } from '../../../Page objects/Login.page';
+import { InsightDashboardPage } from '../InsightDashboard.page';
+import { InsightDashboardDashboardsPage } from '../InsightDashboard-Dashboards.page';
+import { InsightDashboardDashboardViewPage } from '../InsightDashboard-DashboardView.page';
+import {
+  InsightDashboardDashboardEditPage,
+  DashboardTestConfigEditModel,
+} from '../InsightDashboard-DashboardEdit.page';
+import {
+  dashboardCsvExportItems,
+  csvExportTextQuestion,
+} from '../ChartData/DashboardCsvExport.data';
+
+const dashboardName = 'CSV export';
+
+const dashboardConfig: DashboardTestConfigEditModel = {
+  locationTagName: 'Location 1',
+  dateRange: {
+    yearFrom: 2016,
+    monthFrom: 1,
+    dayFrom: 1,
+    yearTo: 2020,
+    monthTo: 6,
+    dayTo: 14,
+  },
+  today: true,
+};
+
+const BOM = '﻿';
+const RECORD_SEPARATOR = '\r\n';
+
+interface ExportedFile {
+  fileName: string;
+  text: string;
+  records: string[];
+}
+
+/** Splits an export into records, dropping the empty tail after the last CRLF. */
+function toRecords(text: string): string[] {
+  const records = text.split(RECORD_SEPARATOR);
+  if (records[records.length - 1] === '') {
+    records.pop();
+  }
+  return records;
+}
+
+function cells(record: string): string[] {
+  return record.split('\t');
+}
+
+/**
+ * A blank record separates one table from the next. The aggregated export holds
+ * several: a chart with more than one raw data block writes one section per
+ * block, and a non grouped chart splits each block into percentages and amounts.
+ */
+function toSections(records: string[]): string[][] {
+  const sections: string[][] = [];
+  let current: string[] = [];
+  for (const record of records) {
+    if (record === '') {
+      sections.push(current);
+      current = [];
+    } else {
+      current.push(record);
+    }
+  }
+  sections.push(current);
+  return sections;
+}
+
+/** Every record in a section describes the same columns as its header. */
+function expectRectangular(section: string[]) {
+  const width = cells(section[0]).length;
+  expect(width).toBeGreaterThan(1);
+  for (const record of section) {
+    expect(cells(record).length).toBe(width);
+  }
+}
+
+test.describe('InSight Dashboard - tab separated CSV export', () => {
+  let page: any;
+  let insightDashboardPage: InsightDashboardPage;
+  let dashboardsPage: InsightDashboardDashboardsPage;
+  let dashboardEditPage: InsightDashboardDashboardEditPage;
+  let dashboardsViewPage: InsightDashboardDashboardViewPage;
+
+  const download = async (locator: any): Promise<ExportedFile> => {
+    const [downloaded] = await Promise.all([
+      page.waitForEvent('download', { timeout: 60000 }),
+      locator.click(),
+    ]);
+    const savedTo = await downloaded.path();
+    const text = fs.readFileSync(savedTo, 'utf8');
+    return {
+      fileName: downloaded.suggestedFilename(),
+      text,
+      records: toRecords(text),
+    };
+  };
+
+  const ensureRawDataExpanded = async (item: number) => {
+    if ((await dashboardsViewPage.rawDataGrid(item).count()) === 0) {
+      await dashboardsViewPage.rawDataToggle(item).click();
+    }
+    await expect(dashboardsViewPage.rawDataGrid(item)).toBeVisible();
+    await expect(dashboardsViewPage.rawDataRows(item).first()).toBeVisible({
+      timeout: 30000,
+    });
+  };
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    const loginPage = new LoginPage(page);
+    insightDashboardPage = new InsightDashboardPage(page);
+    dashboardsPage = new InsightDashboardDashboardsPage(page);
+    dashboardEditPage = new InsightDashboardDashboardEditPage(page);
+    dashboardsViewPage = new InsightDashboardDashboardViewPage(page);
+    await loginPage.open('/auth');
+    await loginPage.login();
+    await insightDashboardPage.goToDashboards();
+    await dashboardsPage.createDashboard(dashboardName);
+    await dashboardEditPage.setDashboardSettings(dashboardConfig);
+    await dashboardEditPage.generateItems(dashboardCsvExportItems);
+
+    // A third item on the survey's text question, which renders the interviews
+    // table instead of a chart.
+    await dashboardEditPage.createItem(
+      await dashboardEditPage.getDashboardItem(dashboardCsvExportItems.length)
+    );
+    await dashboardEditPage.fillTextQuestionItem(
+      dashboardCsvExportItems.length + 1,
+      csvExportTextQuestion.firstQuestion,
+      csvExportTextQuestion.firstQuestionForSelect
+    );
+
+    await dashboardEditPage.dashboardUpdateSaveBtn.click();
+    await page
+      .locator('#spinner-animation')
+      .waitFor({ state: 'hidden', timeout: 40000 });
+    await page.waitForTimeout(1000);
+  });
+
+  test.afterAll(async () => {
+    await insightDashboardPage.goToDashboards();
+    await dashboardsPage.clearTable();
+    await page.close();
+  });
+
+  test('writes a byte order mark, tab fields and CRLF records', async () => {
+    const file = await download(dashboardsViewPage.chartDataExportCsvButton(0));
+
+    expect(file.text.startsWith(BOM)).toBe(true);
+    // The extension says comma; the delimiter is a tab. That is the point.
+    expect(cells(file.records[0]).length).toBeGreaterThan(1);
+    expect(file.text.endsWith(RECORD_SEPARATOR)).toBe(true);
+    // Lone LFs would break the record separator contract.
+    expect(file.text.replace(/\r\n/g, '')).not.toContain('\n');
+  });
+
+  test('names each file after the dashboard, the item and the table', async () => {
+    const chart = await download(dashboardsViewPage.chartDataExportCsvButton(0));
+    expect(chart.fileName).toBe(`${dashboardName}_1_chart_data.csv`);
+
+    const interviewsButton = dashboardsViewPage.interviewsExportCsvButton(
+      dashboardCsvExportItems.length
+    );
+    // The button is only rendered when the item has interviews to export, which
+    // is a property of the seed data rather than of the feature.
+    test.skip(
+      (await interviewsButton.count()) === 0,
+      'Seed data has no interviews in the dashboard period.'
+    );
+
+    const interviews = await download(interviewsButton);
+    expect(interviews.fileName).toBe(
+      `${dashboardName}_${dashboardCsvExportItems.length + 1}_interviews.csv`
+    );
+  });
+
+  test('stacks percentages above amounts for a non grouped chart', async () => {
+    const file = await download(dashboardsViewPage.chartDataExportCsvButton(0));
+    const sections = toSections(file.records);
+
+    // Percentages and amounts are two tables on screen, so they are two sections
+    // in the file - and a chart with several raw data blocks repeats the pair.
+    expect(sections.length).toBeGreaterThanOrEqual(2);
+    expect(sections.length % 2).toBe(0);
+
+    for (let i = 0; i < sections.length; i += 2) {
+      const percents = sections[i];
+      const amounts = sections[i + 1];
+      expectRectangular(percents);
+      expectRectangular(amounts);
+      // Both halves describe the same columns, so they carry the same header.
+      expect(amounts[0]).toBe(percents[0]);
+      expect(percents.length).toBeGreaterThan(1);
+      expect(amounts.length).toBe(percents.length);
+      // Percentages keep the sign the table shows; amounts are bare numbers.
+      expect(percents[1]).toContain('%');
+      expect(amounts[1]).not.toContain('%');
+    }
+  });
+
+  test('keeps percentages and amounts on one row for the stacked grouped chart', async () => {
+    const file = await download(dashboardsViewPage.chartDataExportCsvButton(1));
+
+    for (const section of toSections(file.records)) {
+      expectRectangular(section);
+      expect(section.length).toBeGreaterThan(1);
+
+      for (const record of section.slice(1)) {
+        const values = cells(record);
+        // The group name is promoted from the rowSpan cell to a leading column.
+        expect(values[0].length).toBeGreaterThan(0);
+        // This chart puts both halves on the same row, so a data record carries
+        // percentages and amounts together rather than one or the other.
+        expect(values.some((value) => value.endsWith('%'))).toBe(true);
+        expect(values.slice(2).some((value) => /^\d+$/.test(value))).toBe(true);
+      }
+    }
+  });
+
+  test('exports every raw data row, not just the page on screen', async () => {
+    await ensureRawDataExpanded(0);
+
+    const answerCount = await dashboardsViewPage.rawDataAnswerCount(0);
+    expect(answerCount).not.toBeNull();
+    expect(answerCount as number).toBeGreaterThan(0);
+
+    const onScreenRows = await dashboardsViewPage.rawDataRows(0).count();
+    const file = await download(dashboardsViewPage.rawDataExportCsvButton(0));
+
+    // One header plus one record per answer in the whole result, which is more
+    // than the grid holds whenever the result runs past a single page.
+    expect(file.records.length - 1).toBe(answerCount);
+    if ((answerCount as number) > onScreenRows) {
+      expect(file.records.length - 1).toBeGreaterThan(onScreenRows);
+    }
+  });
+
+  test('exports exactly the raw data columns the grid is showing', async () => {
+    await ensureRawDataExpanded(0);
+
+    const onScreenHeaders = (
+      await dashboardsViewPage.rawDataHeaders(0).allTextContents()
+    ).map((header) => header.trim());
+
+    const file = await download(dashboardsViewPage.rawDataExportCsvButton(0));
+    const fileHeaders = cells(file.records[0]);
+    fileHeaders[0] = fileHeaders[0].replace(BOM, '');
+
+    expect(fileHeaders).toEqual(onScreenHeaders);
+    // Time zone ships hidden behind the column picker and must stay out.
+    expect(fileHeaders).not.toContain('Tidszone');
+
+    const width = fileHeaders.length;
+    for (const record of file.records.slice(1)) {
+      expect(cells(record).length).toBe(width);
+    }
+  });
+
+  test('exports the interviews table with one record per interview', async () => {
+    const item = dashboardCsvExportItems.length;
+    const button = dashboardsViewPage.interviewsExportCsvButton(item);
+    test.skip(
+      (await button.count()) === 0,
+      'Seed data has no interviews in the dashboard period.'
+    );
+
+    const file = await download(button);
+
+    const headers = cells(file.records[0]);
+    headers[0] = headers[0].replace(BOM, '');
+    expect(headers.length).toBe(3);
+    expect(headers[1]).toBe('Tag');
+
+    for (const record of file.records.slice(1)) {
+      expect(cells(record).length).toBeGreaterThanOrEqual(3);
+      // Dates are written the way the grid renders them: dd.MM.yyyy HH:mm:ss.
+      expect(cells(record)[0]).toMatch(/^\d{2}\.\d{2}\.\d{4} \d{2}:\d{2}:\d{2}$/);
+    }
+  });
+});

--- a/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/insight-dashboard-csv-export.spec.ts
+++ b/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/insight-dashboard-csv-export.spec.ts
@@ -213,10 +213,13 @@ test.describe('InSight Dashboard - tab separated CSV export', () => {
       expectRectangular(section);
       expect(section.length).toBeGreaterThan(1);
 
+      // Two leading columns carry the group and the value name, promoted from
+      // the rowSpan cell on screen. Their headers are blank, like the table's.
+      // Whether the group name itself is populated is seed data, not structure.
+      expect(cells(section[0]).slice(0, 2)).toEqual(['', '']);
+
       for (const record of section.slice(1)) {
         const values = cells(record);
-        // The group name is promoted from the rowSpan cell to a leading column.
-        expect(values[0].length).toBeGreaterThan(0);
         // This chart puts both halves on the same row, so a data record carries
         // percentages and amounts together rather than one or the other.
         expect(values.some((value) => value.endsWith('%'))).toBe(true);

--- a/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/insight-dashboard-csv-export.spec.ts
+++ b/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/insight-dashboard-csv-export.spec.ts
@@ -46,8 +46,11 @@ function toRecords(text: string): string[] {
   return records;
 }
 
+/** The byte order mark rides on the very first field of the file. */
 function cells(record: string): string[] {
-  return record.split('\t');
+  const values = record.split('\t');
+  values[0] = values[0].replace(BOM, '');
+  return values;
 }
 
 /**
@@ -194,7 +197,7 @@ test.describe('InSight Dashboard - tab separated CSV export', () => {
       expectRectangular(percents);
       expectRectangular(amounts);
       // Both halves describe the same columns, so they carry the same header.
-      expect(amounts[0]).toBe(percents[0]);
+      expect(cells(amounts[0])).toEqual(cells(percents[0]));
       expect(percents.length).toBeGreaterThan(1);
       expect(amounts.length).toBe(percents.length);
       // Percentages keep the sign the table shows; amounts are bare numbers.
@@ -249,7 +252,6 @@ test.describe('InSight Dashboard - tab separated CSV export', () => {
 
     const file = await download(dashboardsViewPage.rawDataExportCsvButton(0));
     const fileHeaders = cells(file.records[0]);
-    fileHeaders[0] = fileHeaders[0].replace(BOM, '');
 
     expect(fileHeaders).toEqual(onScreenHeaders);
     // Time zone ships hidden behind the column picker and must stay out.
@@ -272,7 +274,6 @@ test.describe('InSight Dashboard - tab separated CSV export', () => {
     const file = await download(button);
 
     const headers = cells(file.records[0]);
-    headers[0] = headers[0].replace(BOM, '');
     expect(headers.length).toBe(3);
     expect(headers[1]).toBe('Tag');
 

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-block-view/dashboard-block-view.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-block-view/dashboard-block-view.component.html
@@ -50,7 +50,10 @@
             [chartPosition]="position"
             [itemModel]="itemModel">
           </app-dashboard-chart-view>
-          <app-dashboard-chart-data-view [itemModel]="itemModel"></app-dashboard-chart-data-view>
+          <app-dashboard-chart-data-view
+            [dashboardViewModel]="dashboardViewModel"
+            [itemModel]="itemModel">
+          </app-dashboard-chart-data-view>
           <app-dashboard-raw-data-view
             [dashboardViewModel]="dashboardViewModel"
             [itemModel]="itemModel">

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.html
@@ -1,4 +1,15 @@
 <!--suppress XmlDuplicatedId -->
+<div class="d-flex justify-content-end" *ngIf="canExport">
+  <button
+    mat-icon-button
+    color="accent"
+    (click)="exportToCsv()"
+    id="dashboardChartDataExportCsv{{itemModel.position}}"
+    [matTooltip]="'Export to CSV' | translate"
+  >
+    <mat-icon>file_download</mat-icon>
+  </button>
+</div>
 <div class="mtx-grid" [ngClass]="{'mt-2': !rawDataIndexFirst}" *ngFor="let rawData of itemModel.chartData.rawData; let rawDataIndex = index; let rawDataIndexFirst = first">
   <div class="mtx-grid-main mtx-grid-layout">
     <div class="mtx-grid-content mtx-grid-layout">

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.spec.ts
@@ -1,24 +1,182 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {NO_ERRORS_SCHEMA, Pipe, PipeTransform} from '@angular/core';
+import {of} from 'rxjs';
+import {Store} from '@ngrx/store';
+import {DashboardChartDataViewComponent} from './dashboard-chart-data-view.component';
+import {DashboardChartTypesEnum} from '../../../../const';
+import * as tsvExport from '../../../../helpers/tsv-export.helper';
 
-import { DashboardChartDataViewComponent } from './dashboard-chart-data-view.component';
+@Pipe({name: 'translate', standalone: false})
+class MockTranslatePipe implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
 
 describe('DashboardChartDataViewComponent', () => {
   let component: DashboardChartDataViewComponent;
   let fixture: ComponentFixture<DashboardChartDataViewComponent>;
+  let downloadSpy: jest.SpyInstance;
 
-  beforeEach(async(() => {
+  const block = (rawValueName: string) => ({
+    rawHeaders: ['Jan 2020', 'Feb 2020'],
+    rawDataItems: [
+      {
+        rawValueName,
+        rawDataValues: [
+          {valueName: 'Glad', percents: [82, 74], amounts: [41, 33]},
+          {valueName: 'Total', percents: [100, 100], amounts: [50, 45]},
+        ],
+      },
+    ],
+  });
+
+  const setUp = (
+    chartType: DashboardChartTypesEnum,
+    rawData: any[],
+    calculateAverage = false
+  ) => {
+    component.dashboardViewModel = {id: 9, dashboardName: 'My board'} as any;
+    component.itemModel = {
+      position: 3,
+      chartType,
+      calculateAverage,
+      chartData: {rawData},
+    } as any;
+    fixture.detectChanges();
+  };
+
+  const exportedTsv = (): string => downloadSpy.mock.calls[0][1];
+  const exportedFileName = (): string => downloadSpy.mock.calls[0][0];
+
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [DashboardChartDataViewComponent],
+      declarations: [DashboardChartDataViewComponent, MockTranslatePipe],
+      providers: [{provide: Store, useValue: {select: () => of(false)}}],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
 
   beforeEach(() => {
+    downloadSpy = jest
+      .spyOn(tsvExport, 'downloadTsv')
+      .mockImplementation(() => {});
     fixture = TestBed.createComponent(DashboardChartDataViewComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
+  afterEach(() => downloadSpy.mockRestore());
+
   it('should create', () => {
+    setUp(DashboardChartTypesEnum.Line, [block('')]);
     expect(component).toBeTruthy();
+  });
+
+  describe('canExport', () => {
+    it('is false when the item carries no chart data at all', () => {
+      component.itemModel = {position: 1} as any;
+      expect(component.canExport).toBe(false);
+    });
+
+    it('is false when the chart data holds no blocks', () => {
+      setUp(DashboardChartTypesEnum.Line, []);
+      expect(component.canExport).toBe(false);
+    });
+
+    it('is true once there is a block to export', () => {
+      setUp(DashboardChartTypesEnum.Line, [block('')]);
+      expect(component.canExport).toBe(true);
+    });
+  });
+
+  describe('exportToCsv', () => {
+    it('writes a percent section then an amount section', () => {
+      setUp(DashboardChartTypesEnum.Line, [block('')]);
+      component.exportToCsv();
+
+      expect(exportedTsv()).toBe(
+        `${tsvExport.TSV_BOM}` +
+          '\tJan 2020\tFeb 2020\r\n' +
+          'Glad\t82%\t74%\r\n' +
+          'Total\t100%\t100%\r\n' +
+          '\r\n' +
+          '\tJan 2020\tFeb 2020\r\n' +
+          'Glad\t41\t33\r\n' +
+          'Total\t50\t45\r\n'
+      );
+    });
+
+    it('names the file after the dashboard and the item position', () => {
+      setUp(DashboardChartTypesEnum.Line, [block('')]);
+      component.exportToCsv();
+      expect(exportedFileName()).toBe('My board_3_chart_data.csv');
+    });
+
+    it('drops the percent sign when the item shows averages', () => {
+      setUp(DashboardChartTypesEnum.Line, [block('')], true);
+      component.exportToCsv();
+
+      const percentRow = exportedTsv().split('\r\n')[1];
+      expect(percentRow).toBe('Glad\t82\t74');
+    });
+
+    it('keeps percentages and amounts on one row for the stacked grouped chart', () => {
+      // This chart renders both halves side by side under a single header row
+      // that already names them, and carries the group in a rowSpan cell. The
+      // file therefore stays one section, with the group promoted to a column.
+      setUp(DashboardChartTypesEnum.HorizontalBarStackedGrouped, [
+        {
+          rawHeaders: ['Jan 2020', 'Feb 2020', '%', 'Jan 2020', 'Feb 2020', 'n'],
+          rawDataItems: [
+            {
+              rawValueName: 'Location 1',
+              rawDataValues: [
+                {
+                  valueName: 'Glad',
+                  percents: [82, 74, 100],
+                  amounts: [41, 33, 74],
+                },
+              ],
+            },
+            {
+              rawValueName: 'Location 2',
+              rawDataValues: [
+                {
+                  valueName: 'Glad',
+                  percents: [61, 55, 100],
+                  amounts: [22, 19, 41],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+      component.exportToCsv();
+
+      expect(exportedTsv()).toBe(
+        `${tsvExport.TSV_BOM}` +
+          '\t\tJan 2020\tFeb 2020\t%\tJan 2020\tFeb 2020\tn\r\n' +
+          'Location 1\tGlad\t82%\t74%\t100%\t41\t33\t74\r\n' +
+          'Location 2\tGlad\t61%\t55%\t100%\t22\t19\t41\r\n'
+      );
+    });
+
+    it('writes every block, separated by a blank record', () => {
+      setUp(DashboardChartTypesEnum.Line, [block(''), block('')]);
+      component.exportToCsv();
+
+      // two sections per block, each separated by one blank record
+      const blankRecords = exportedTsv()
+        .split('\r\n')
+        .filter((record) => record === '').length;
+      // three separators plus the empty tail after the terminating CRLF
+      expect(blankRecords).toBe(4);
+    });
+
+    it('does nothing when there is nothing to export', () => {
+      setUp(DashboardChartTypesEnum.Line, []);
+      component.exportToCsv();
+      expect(downloadSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.spec.ts
@@ -161,6 +161,52 @@ describe('DashboardChartDataViewComponent', () => {
       );
     });
 
+    it('repeats grouped headers that only name one of the two halves', () => {
+      // When the block groups by period, rawHeaders covers the percentages only
+      // and the screen renders a header row narrower than its own body. The file
+      // has to stay rectangular, so the headers are repeated for the amounts.
+      setUp(DashboardChartTypesEnum.HorizontalBarStackedGrouped, [
+        {
+          rawHeaders: ['16_01', '16_05'],
+          rawDataItems: [
+            {
+              rawValueName: 'Location 1',
+              rawDataValues: [
+                {valueName: 'Glad', percents: [82, 74], amounts: [41, 33]},
+              ],
+            },
+          ],
+        },
+      ]);
+      component.exportToCsv();
+
+      expect(exportedTsv()).toBe(
+        `${tsvExport.TSV_BOM}` +
+          '\t\t16_01\t16_05\t16_01\t16_05\r\n' +
+          'Location 1\tGlad\t82%\t74%\t41\t33\r\n'
+      );
+    });
+
+    it('pads grouped headers that match neither half', () => {
+      setUp(DashboardChartTypesEnum.HorizontalBarStackedGrouped, [
+        {
+          rawHeaders: ['16_01', '16_05', '16_09'],
+          rawDataItems: [
+            {
+              rawValueName: 'Location 1',
+              rawDataValues: [
+                {valueName: 'Glad', percents: [82, 74], amounts: [41, 33]},
+              ],
+            },
+          ],
+        },
+      ]);
+      component.exportToCsv();
+
+      const records = exportedTsv().split('\r\n');
+      expect(records[0].split('\t').length).toBe(records[1].split('\t').length);
+    });
+
     it('writes every block, separated by a blank record', () => {
       setUp(DashboardChartTypesEnum.Line, [block(''), block('')]);
       component.exportToCsv();

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.ts
@@ -1,11 +1,17 @@
 import {Component, inject, Input, OnDestroy, OnInit} from '@angular/core';
-import {DashboardViewItemModel} from '../../../../models';
+import {DashboardViewItemModel, DashboardViewModel} from '../../../../models';
 import { DashboardChartTypesEnum } from '../../../../const';
 import { AuthStateService } from 'src/app/common/store';
 import { AutoUnsubscribe } from 'ngx-auto-unsubscribe';
 import { Subscription } from 'rxjs';
 import {Store} from '@ngrx/store';
 import {selectIsDarkMode} from 'src/app/state/auth/auth.selector';
+import {
+  TsvSection,
+  buildTsv,
+  downloadTsv,
+  tsvFileName,
+} from '../../../../helpers/tsv-export.helper';
 
 @AutoUnsubscribe()
 @Component({
@@ -17,12 +23,20 @@ import {selectIsDarkMode} from 'src/app/state/auth/auth.selector';
 export class DashboardChartDataViewComponent implements OnInit, OnDestroy {
   private store = inject(Store);
 
+  @Input() dashboardViewModel: DashboardViewModel = new DashboardViewModel();
   @Input() itemModel: DashboardViewItemModel = new DashboardViewItemModel();
   darkTheme: boolean;
   getDarkThemeSub$: Subscription;
 
   get chartTypes() {
     return DashboardChartTypesEnum;
+  }
+
+  get canExport(): boolean {
+    const rawData = this.itemModel && this.itemModel.chartData
+      ? this.itemModel.chartData.rawData
+      : null;
+    return !!rawData && rawData.length > 0;
   }
 
   constructor() {
@@ -34,6 +48,83 @@ export class DashboardChartDataViewComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {}
+
+  exportToCsv() {
+    if (!this.canExport) {
+      return;
+    }
+    downloadTsv(
+      tsvFileName(
+        this.dashboardViewModel.dashboardName,
+        this.itemModel.position,
+        'chart_data'
+      ),
+      buildTsv(this.buildSections())
+    );
+  }
+
+  /**
+   * The file reproduces the rendered table, and the two chart shapes render
+   * differently.
+   *
+   * The stacked grouped chart puts percentages and amounts side by side in one
+   * row, under one header row that already names both halves, so it exports as a
+   * single section per block. Its group name lives in a rowSpan cell on screen;
+   * in the file it becomes a leading column repeated on every row.
+   *
+   * Every other chart type stacks a percentage table above an amount table,
+   * both under the same headers, so each of those becomes its own section.
+   */
+  private buildSections(): TsvSection[] {
+    const grouped =
+      this.itemModel.chartType ===
+      DashboardChartTypesEnum.HorizontalBarStackedGrouped;
+
+    const sections: TsvSection[] = [];
+
+    for (const block of this.itemModel.chartData.rawData) {
+      if (grouped) {
+        sections.push({
+          headers: ['', '', ...block.rawHeaders],
+          rows: block.rawDataItems.flatMap((dataItem) =>
+            dataItem.rawDataValues.map((dataValue) => [
+              dataItem.rawValueName,
+              dataValue.valueName,
+              ...dataValue.percents.map((percent) => this.formatPercent(percent)),
+              ...dataValue.amounts.map((amount) => String(amount)),
+            ])
+          ),
+        });
+        continue;
+      }
+
+      const headers = ['', ...block.rawHeaders];
+      for (const dataItem of block.rawDataItems) {
+        sections.push({
+          headers,
+          rows: dataItem.rawDataValues.map((dataValue) => [
+            dataValue.valueName,
+            ...dataValue.percents.map((percent) => this.formatPercent(percent)),
+          ]),
+        });
+        sections.push({
+          headers,
+          rows: dataItem.rawDataValues.map((dataValue) => [
+            dataValue.valueName,
+            ...dataValue.amounts.map((amount) => String(amount)),
+          ]),
+        });
+      }
+    }
+
+    return sections;
+  }
+
+  // An average is not a percentage - the table drops the sign for those, and so
+  // must the file, or the number reads as a percentage in the spreadsheet.
+  private formatPercent(percent: number): string {
+    return this.itemModel.calculateAverage ? String(percent) : `${percent}%`;
+  }
 
   ngOnDestroy(): void {}
 }

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.ts
@@ -84,16 +84,22 @@ export class DashboardChartDataViewComponent implements OnInit, OnDestroy {
 
     for (const block of this.itemModel.chartData.rawData) {
       if (grouped) {
+        const rows = block.rawDataItems.flatMap((dataItem) =>
+          dataItem.rawDataValues.map((dataValue) => [
+            dataItem.rawValueName,
+            dataValue.valueName,
+            ...dataValue.percents.map((percent) => this.formatPercent(percent)),
+            ...dataValue.amounts.map((amount) => String(amount)),
+          ])
+        );
+        // The two leading cells are the group and the value name; the rest are
+        // the percentages and amounts the headers have to cover.
+        const valueWidth = rows.length
+          ? rows[0].length - 2
+          : block.rawHeaders.length;
         sections.push({
-          headers: ['', '', ...block.rawHeaders],
-          rows: block.rawDataItems.flatMap((dataItem) =>
-            dataItem.rawDataValues.map((dataValue) => [
-              dataItem.rawValueName,
-              dataValue.valueName,
-              ...dataValue.percents.map((percent) => this.formatPercent(percent)),
-              ...dataValue.amounts.map((amount) => String(amount)),
-            ])
-          ),
+          headers: ['', '', ...this.groupedHeaders(block.rawHeaders, valueWidth)],
+          rows,
         });
         continue;
       }
@@ -118,6 +124,27 @@ export class DashboardChartDataViewComponent implements OnInit, OnDestroy {
     }
 
     return sections;
+  }
+
+  /**
+   * The stacked grouped chart puts percentages and amounts side by side in one
+   * row, but rawHeaders does not consistently describe both halves: when the
+   * block groups by answer option it names both, when it groups by period it
+   * names one and the screen renders a header row narrower than its own body.
+   *
+   * Size the header row to the data either way. A file whose header row is
+   * narrower than its records is not a table any spreadsheet can read, so this
+   * is one place the export deliberately does not reproduce the screen.
+   */
+  private groupedHeaders(rawHeaders: string[], valueWidth: number): string[] {
+    const headers =
+      rawHeaders.length >= valueWidth
+        ? [...rawHeaders]
+        : [...rawHeaders, ...rawHeaders];
+    while (headers.length < valueWidth) {
+      headers.push('');
+    }
+    return headers.slice(0, valueWidth);
   }
 
   // An average is not a percentage - the table drops the sign for those, and so

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-interviews-view/dashboard-interviews-view.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-interviews-view/dashboard-interviews-view.component.html
@@ -1,3 +1,15 @@
+<div class="d-flex justify-content-end" *ngIf="canExport">
+  <button
+    mat-icon-button
+    color="accent"
+    (click)="exportToCsv()"
+    id="dashboardInterviewsExportCsv{{itemModel.position}}"
+    [matTooltip]="'Export to CSV' | translate"
+  >
+    <mat-icon>file_download</mat-icon>
+  </button>
+</div>
+
 <mtx-grid
 [data]="itemModel.textQuestionData"
 [columns]="tableHeaders"
@@ -5,11 +17,3 @@
 [pageOnFront]="false"
 [rowStriped]="true"
 ></mtx-grid>
-
-<!--<button mdbBtn-->
-<!--        id="exportInterviewsToCsvBtn"-->
-<!--        class="btn-success btn-icon"-->
-<!--        mdbTooltip="{{ 'Export to CSV' | translate }}"-->
-<!--        (click)="exportToCsv()">-->
-<!--  <fa-icon icon="file-csv" [fixedWidth]="true" size="lg"></fa-icon>-->
-<!--</button>-->

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-interviews-view/dashboard-interviews-view.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-interviews-view/dashboard-interviews-view.component.spec.ts
@@ -1,24 +1,132 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {LOCALE_ID, NO_ERRORS_SCHEMA, Pipe, PipeTransform} from '@angular/core';
+import {of} from 'rxjs';
+import {TranslateService} from '@ngx-translate/core';
+import {DashboardInterviewsViewComponent} from './dashboard-interviews-view.component';
+import {InsightDashboardPnDashboardItemsService} from '../../../../services';
+import * as tsvExport from '../../../../helpers/tsv-export.helper';
 
-import { DashboardInterviewsViewComponent } from './dashboard-interviews-view.component';
+@Pipe({name: 'translate', standalone: false})
+class MockTranslatePipe implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
 
 describe('DashboardInterviewsViewComponent', () => {
   let component: DashboardInterviewsViewComponent;
   let fixture: ComponentFixture<DashboardInterviewsViewComponent>;
+  let downloadSpy: jest.SpyInstance;
 
-  beforeEach(async(() => {
+  const dashboardItemsServiceMock = {
+    exportInterviewsToExcel: jest.fn(() => of(new Blob())),
+  };
+
+  const setUp = (textQuestionData: any[]) => {
+    component.dashboardViewModel = {id: 9, dashboardName: 'My board'} as any;
+    component.itemModel = {id: 4, position: 2, textQuestionData} as any;
+    fixture.detectChanges();
+  };
+
+  const exportedTsv = (): string => downloadSpy.mock.calls[0][1];
+
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [DashboardInterviewsViewComponent],
+      declarations: [DashboardInterviewsViewComponent, MockTranslatePipe],
+      providers: [
+        {provide: LOCALE_ID, useValue: 'en-US'},
+        {
+          provide: InsightDashboardPnDashboardItemsService,
+          useValue: dashboardItemsServiceMock,
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            stream: (key: string) => of(key),
+            get: (key: string) => of(key),
+            instant: (key: string) => key,
+          },
+        },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
 
   beforeEach(() => {
+    downloadSpy = jest
+      .spyOn(tsvExport, 'downloadTsv')
+      .mockImplementation(() => {});
     fixture = TestBed.createComponent(DashboardInterviewsViewComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
+  afterEach(() => downloadSpy.mockRestore());
+
   it('should create', () => {
+    setUp([]);
     expect(component).toBeTruthy();
+  });
+
+  describe('canExport', () => {
+    it('is false without any interviews', () => {
+      setUp([]);
+      expect(component.canExport).toBe(false);
+    });
+
+    it('is true once there is an interview', () => {
+      setUp([{date: new Date(2026, 2, 2), locationName: 'A', commentary: 'B'}]);
+      expect(component.canExport).toBe(true);
+    });
+  });
+
+  describe('exportToCsv', () => {
+    it('writes the grid headers and one record per interview', () => {
+      setUp([
+        {
+          date: new Date(2026, 2, 2, 8, 14, 22),
+          locationName: 'Location 1',
+          commentary: 'All good',
+        },
+      ]);
+      component.exportToCsv();
+
+      expect(exportedTsv()).toBe(
+        `${tsvExport.TSV_BOM}` +
+          'Date\tTag\tComments\r\n' +
+          '02.03.2026 08:14:22\tLocation 1\tAll good\r\n'
+      );
+    });
+
+    it('names the file after the dashboard and the item position', () => {
+      setUp([{date: new Date(2026, 2, 2), locationName: 'A', commentary: 'B'}]);
+      component.exportToCsv();
+      expect(downloadSpy.mock.calls[0][0]).toBe('My board_2_interviews.csv');
+    });
+
+    it('quotes a comment that carries a tab or a line break', () => {
+      setUp([
+        {
+          date: new Date(2026, 2, 2, 8, 14, 22),
+          locationName: 'Location 1',
+          commentary: 'first\tsecond\nthird',
+        },
+      ]);
+      component.exportToCsv();
+
+      expect(exportedTsv()).toContain('"first\tsecond\nthird"');
+    });
+
+    it('leaves the date cell empty rather than throwing on a missing date', () => {
+      setUp([{date: null, locationName: 'Location 1', commentary: 'All good'}]);
+      component.exportToCsv();
+
+      expect(exportedTsv().split('\r\n')[1]).toBe('\tLocation 1\tAll good');
+    });
+
+    it('does nothing when there are no interviews', () => {
+      setUp([]);
+      component.exportToCsv();
+      expect(downloadSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-interviews-view/dashboard-interviews-view.component.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-interviews-view/dashboard-interviews-view.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, Input, LOCALE_ID, OnDestroy, OnInit } from '@angular/core';
+import { formatDate } from '@angular/common';
 import { AutoUnsubscribe } from 'ngx-auto-unsubscribe';
 import { Subscription } from 'rxjs';
 import { InsightDashboardPnDashboardItemsService } from '../../../../services';
@@ -6,6 +7,13 @@ import { saveAs } from 'file-saver';
 import { DashboardViewModel, DashboardViewItemModel} from '../../../../models';
 import {MtxGridColumn} from "@ng-matero/extensions/grid";
 import {TranslateService} from "@ngx-translate/core";
+import {
+  buildTsv,
+  downloadTsv,
+  tsvFileName,
+} from '../../../../helpers/tsv-export.helper';
+
+const DATE_FORMAT = 'dd.MM.y HH:mm:ss';
 
 @AutoUnsubscribe()
 @Component({
@@ -17,6 +25,7 @@ import {TranslateService} from "@ngx-translate/core";
 export class DashboardInterviewsViewComponent implements OnInit, OnDestroy {
   private translateService = inject(TranslateService);
   private dashboardItemsService = inject(InsightDashboardPnDashboardItemsService);
+  private locale = inject(LOCALE_ID);
 
   @Input() dashboardViewModel: DashboardViewModel = new DashboardViewModel();
   @Input() itemModel: DashboardViewItemModel = new DashboardViewItemModel();
@@ -26,14 +35,45 @@ export class DashboardInterviewsViewComponent implements OnInit, OnDestroy {
   tableHeaders: MtxGridColumn[] = [
     {header: this.translateService.stream('Date'), field: 'date',
       type: 'date',
-      typeParameter: {format: 'dd.MM.y HH:mm:ss'}},
+      typeParameter: {format: DATE_FORMAT}},
     {header: this.translateService.stream('Tag'), field: 'locationName'},
     { header: this.translateService.stream('Comments'), field: 'commentary', },
   ]
 
+  get canExport(): boolean {
+    return !!this.itemModel.textQuestionData && this.itemModel.textQuestionData.length > 0;
+  }
+
   ngOnInit() {}
 
   exportToCsv() {
+    if (!this.canExport) {
+      return;
+    }
+    // The grid already holds every interview - there is no paging here - so the
+    // file is built from what is on screen without going back to the server.
+    downloadTsv(
+      tsvFileName(
+        this.dashboardViewModel.dashboardName,
+        this.itemModel.position,
+        'interviews'
+      ),
+      buildTsv([
+        {
+          headers: ['Date', 'Tag', 'Comments'].map((key) =>
+            this.translateService.instant(key)
+          ),
+          rows: this.itemModel.textQuestionData.map((interview) => [
+            interview.date ? formatDate(interview.date, DATE_FORMAT, this.locale) : '',
+            interview.locationName,
+            interview.commentary,
+          ]),
+        },
+      ])
+    );
+  }
+
+  exportToExcel() {
     this.exportSub$ = this.dashboardItemsService
       .exportInterviewsToExcel({
         dashboardId: this.dashboardViewModel.id,

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-raw-data-view/dashboard-raw-data-view.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-raw-data-view/dashboard-raw-data-view.component.html
@@ -16,6 +16,16 @@
     <button
       mat-icon-button
       color="accent"
+      (click)="exportToCsv()"
+      [disabled]="!canExport || exportingCsv"
+      id="dashboardRawDataExportCsv{{itemModel.position}}"
+      [matTooltip]="'Export to CSV' | translate"
+    >
+      <mat-icon>file_download</mat-icon>
+    </button>
+    <button
+      mat-icon-button
+      color="accent"
       (click)="exportToExcel()"
       id="dashboardRawDataExport{{itemModel.position}}"
       [matTooltip]="'Export raw data' | translate"

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-raw-data-view/dashboard-raw-data-view.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-raw-data-view/dashboard-raw-data-view.component.spec.ts
@@ -4,6 +4,7 @@ import {of} from 'rxjs';
 import {TranslateService} from '@ngx-translate/core';
 import {DashboardRawDataViewComponent} from './dashboard-raw-data-view.component';
 import {InsightDashboardPnRawDataService} from '../../../../services';
+import * as tsvExport from '../../../../helpers/tsv-export.helper';
 
 @Pipe({name: 'translate', standalone: false})
 class MockTranslatePipe implements PipeTransform {
@@ -143,5 +144,88 @@ describe('DashboardRawDataViewComponent', () => {
     expect(component.rows.length).toBe(0);
     expect(component.tableHeaders.length).toBe(0);
     expect(component.total).toBe(0);
+  });
+
+  describe('exportToCsv', () => {
+    let downloadSpy: jest.SpyInstance;
+
+    const exportedTsv = (): string => downloadSpy.mock.calls[0][1];
+
+    beforeEach(() => {
+      downloadSpy = jest
+        .spyOn(tsvExport, 'downloadTsv')
+        .mockImplementation(() => {});
+    });
+
+    afterEach(() => downloadSpy.mockRestore());
+
+    it('is not offered before the table has loaded or when it is empty', () => {
+      expect(component.canExport).toBe(false);
+
+      component.toggle();
+      expect(component.canExport).toBe(true);
+
+      component.total = 0;
+      expect(component.canExport).toBe(false);
+    });
+
+    it('asks for every row in the current order, not just the page on screen', () => {
+      component.toggle();
+      component.sortTable({active: 'siteName', direction: 'asc'} as any);
+      rawDataServiceMock.getRawData.mockClear();
+
+      component.exportToCsv();
+
+      expect(rawDataServiceMock.getRawData).toHaveBeenCalledWith({
+        dashboardId: 3,
+        dashboardItemId: 9,
+        offset: 0,
+        pageSize: 2,
+        sort: 'siteName',
+        isSortDsc: false,
+      });
+    });
+
+    it('writes only the columns the grid is showing', () => {
+      component.toggle();
+      // timeZone arrives hidden by default and must stay out of the file.
+      component.exportToCsv();
+
+      expect(exportedTsv()).toBe(
+        `${tsvExport.TSV_BOM}` +
+          'Finished at\t2 – Områder › Kantine\r\n' +
+          '2026-03-02T08:14:22\tKantine\r\n' +
+          '2026-03-03T07:22:11\t\r\n'
+      );
+    });
+
+    it('follows the column picker when a hidden column is revealed', () => {
+      component.toggle();
+      component.tableHeaders.find((c) => c.field === 'timeZone').hide = false;
+
+      component.exportToCsv();
+
+      expect(exportedTsv().split('\r\n')[0]).toBe(
+        `${tsvExport.TSV_BOM}Finished at\tTime zone\t2 – Områder › Kantine`
+      );
+    });
+
+    it('names the file after the dashboard and the item position', () => {
+      component.toggle();
+      component.exportToCsv();
+      expect(downloadSpy.mock.calls[0][0]).toBe('Test_1_raw_data.csv');
+    });
+
+    it('writes nothing when the refetch fails', () => {
+      component.toggle();
+      rawDataServiceMock.getRawData.mockReturnValueOnce(
+        of({success: false, model: null} as any)
+      );
+
+      component.exportToCsv();
+
+      expect(downloadSpy).not.toHaveBeenCalled();
+      expect(component.exportingCsv).toBe(false);
+    });
   });
 });

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-raw-data-view/dashboard-raw-data-view.component.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-raw-data-view/dashboard-raw-data-view.component.ts
@@ -13,6 +13,11 @@ import {
   DashboardViewModel,
   RawDataColumnModel,
 } from '../../../../models';
+import {
+  buildTsv,
+  downloadTsv,
+  tsvFileName,
+} from '../../../../helpers/tsv-export.helper';
 
 @AutoUnsubscribe()
 @Component({
@@ -38,11 +43,18 @@ export class DashboardRawDataViewComponent implements OnChanges, OnDestroy {
   sort = 'finishedAt';
   isSortDsc = true;
 
+  exportingCsv = false;
+
   getRawDataSub$: Subscription;
   exportSub$: Subscription;
+  exportCsvSub$: Subscription;
 
   get sortDirection(): 'asc' | 'desc' {
     return this.isSortDsc ? 'desc' : 'asc';
+  }
+
+  get canExport(): boolean {
+    return this.loaded && this.total > 0;
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -145,6 +157,69 @@ export class DashboardRawDataViewComponent implements OnChanges, OnDestroy {
           `${this.dashboardViewModel.dashboardName}_raw_data.xlsx`
         );
       });
+  }
+
+  /**
+   * The grid only holds the page on screen, so the file is built from a second
+   * call asking the same endpoint for every row in the order currently shown.
+   * Unlike the Excel export, this one carries exactly the columns the grid is
+   * showing - the column picker decides what lands in the file.
+   */
+  exportToCsv() {
+    if (!this.canExport || this.exportingCsv) {
+      return;
+    }
+    this.exportingCsv = true;
+    this.exportCsvSub$ = this.rawDataService
+      .getRawData({
+        dashboardId: this.dashboardViewModel.id,
+        dashboardItemId: this.itemModel.id,
+        offset: 0,
+        pageSize: this.total,
+        sort: this.sort,
+        isSortDsc: this.isSortDsc,
+      })
+      .subscribe((data) => {
+        this.exportingCsv = false;
+        if (!data || !data.success || !data.model) {
+          return;
+        }
+        const columns = data.model.columns.filter((column) =>
+          this.isVisible(column.field)
+        );
+        downloadTsv(
+          tsvFileName(
+            this.dashboardViewModel.dashboardName,
+            this.itemModel.position,
+            'raw_data'
+          ),
+          buildTsv([
+            {
+              headers: columns.map((column) => this.headerText(column)),
+              rows: data.model.rows.map((row) =>
+                columns.map((column) => this.cellText(row[column.field]))
+              ),
+            },
+          ])
+        );
+      });
+  }
+
+  private isVisible(field: string): boolean {
+    // mtx-grid toggles `hide` on the very objects handed to it, so this reads
+    // back whatever the user last chose in the column menu.
+    const column = this.tableHeaders.find((header) => header.field === field);
+    return !!column && !column.hide;
+  }
+
+  private headerText(column: RawDataColumnModel): string {
+    return column.kind === 'answer'
+      ? this.translateService.instant(column.header)
+      : column.header;
+  }
+
+  private cellText(value: unknown): string {
+    return value === null || value === undefined ? '' : String(value);
   }
 
   ngOnDestroy(): void {}

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/helpers/tsv-export.helper.spec.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/helpers/tsv-export.helper.spec.ts
@@ -1,0 +1,104 @@
+import {
+  TSV_BOM,
+  TsvSection,
+  buildTsv,
+  escapeTsvField,
+  tsvFileName,
+} from './tsv-export.helper';
+
+describe('tsv-export.helper', () => {
+  describe('escapeTsvField', () => {
+    it('leaves a plain value untouched', () => {
+      expect(escapeTsvField('Kantine')).toBe('Kantine');
+    });
+
+    it('turns null and undefined into an empty field', () => {
+      expect(escapeTsvField(null)).toBe('');
+      expect(escapeTsvField(undefined)).toBe('');
+    });
+
+    it('keeps a zero rather than dropping it as falsy', () => {
+      expect(escapeTsvField(0)).toBe('0');
+    });
+
+    it('quotes a value containing the delimiter', () => {
+      expect(escapeTsvField('a\tb')).toBe('"a\tb"');
+    });
+
+    it('quotes a value containing a newline', () => {
+      expect(escapeTsvField('line one\nline two')).toBe('"line one\nline two"');
+      expect(escapeTsvField('line one\r\nline two')).toBe('"line one\r\nline two"');
+    });
+
+    it('quotes a value containing a quote and doubles the inner quotes', () => {
+      expect(escapeTsvField('he said "no"')).toBe('"he said ""no"""');
+    });
+  });
+
+  describe('buildTsv', () => {
+    const singleSection: TsvSection[] = [
+      {headers: ['Date', 'Tag'], rows: [['2026-03-02', 'Location 1']]},
+    ];
+
+    it('starts with a byte order mark exactly once', () => {
+      const tsv = buildTsv(singleSection);
+      expect(tsv.startsWith(TSV_BOM)).toBe(true);
+      expect(tsv.slice(1)).not.toContain(TSV_BOM);
+    });
+
+    it('separates fields with a tab', () => {
+      const tsv = buildTsv(singleSection);
+      expect(tsv.slice(TSV_BOM.length).split('\r\n')[0]).toBe('Date\tTag');
+    });
+
+    it('separates records with CRLF and terminates the last one', () => {
+      const tsv = buildTsv(singleSection);
+      expect(tsv).toBe(`${TSV_BOM}Date\tTag\r\n2026-03-02\tLocation 1\r\n`);
+    });
+
+    it('separates sections with one blank record', () => {
+      const tsv = buildTsv([
+        {headers: ['', 'Jan'], rows: [['Glad', '82%']]},
+        {headers: ['', 'Jan'], rows: [['Glad', '41']]},
+      ]);
+      expect(tsv).toBe(
+        `${TSV_BOM}\tJan\r\nGlad\t82%\r\n\r\n\tJan\r\nGlad\t41\r\n`
+      );
+    });
+
+    it('allows a section without headers', () => {
+      expect(buildTsv([{rows: [['a', 'b']]}])).toBe(`${TSV_BOM}a\tb\r\n`);
+    });
+
+    it('escapes every field it writes, headers included', () => {
+      const tsv = buildTsv([
+        {headers: ['a\tb'], rows: [['he said "no"']]},
+      ]);
+      expect(tsv).toBe(`${TSV_BOM}"a\tb"\r\n"he said ""no"""\r\n`);
+    });
+
+    it('produces just the marker when there is nothing to write', () => {
+      expect(buildTsv([])).toBe(TSV_BOM);
+      expect(buildTsv([{rows: []}])).toBe(TSV_BOM);
+    });
+  });
+
+  describe('tsvFileName', () => {
+    it('joins the dashboard name, position and suffix', () => {
+      expect(tsvFileName('Raw data', 2, 'raw_data')).toBe('Raw data_2_raw_data.csv');
+    });
+
+    it('replaces characters a file system will not take', () => {
+      expect(tsvFileName('a/b:c*d?e"f<g>h|i\\j', 1, 'interviews')).toBe(
+        'a_b_c_d_e_f_g_h_i_j_1_interviews.csv'
+      );
+    });
+
+    it('falls back when the name is empty or entirely illegal', () => {
+      expect(tsvFileName('', 1, 'chart_data')).toBe('dashboard_1_chart_data.csv');
+      expect(tsvFileName('   ', 1, 'chart_data')).toBe('dashboard_1_chart_data.csv');
+      expect(tsvFileName('///', 1, 'chart_data')).toBe('dashboard_1_chart_data.csv');
+      expect(tsvFileName(null, 1, 'chart_data')).toBe('dashboard_1_chart_data.csv');
+    });
+  });
+});

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/helpers/tsv-export.helper.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/helpers/tsv-export.helper.ts
@@ -1,0 +1,79 @@
+import {saveAs} from 'file-saver';
+
+/**
+ * The dashboard tables export as tab-separated text carrying a .csv extension.
+ * The contradiction is deliberate: users ask for "CSV", but Excel on a Danish
+ * locale opens tab-delimited text without a wizard, and a tab practically never
+ * occurs inside survey text.
+ */
+const FIELD_SEPARATOR = '\t';
+const RECORD_SEPARATOR = '\r\n';
+
+/** Without it Excel guesses the code page and mangles æ, ø and å. */
+export const TSV_BOM = '﻿';
+
+const NEEDS_QUOTING = /[\t\r\n"]/;
+const ILLEGAL_IN_FILE_NAME = /[\\/:*?"<>|\x00-\x1f]/g;
+
+/**
+ * One block of records. The chart data table is really two stacked tables -
+ * percentages then amounts - so an export is a list of these, not a single
+ * header/rows pair.
+ */
+export interface TsvSection {
+  headers?: string[];
+  rows: string[][];
+}
+
+export function escapeTsvField(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const text = String(value);
+  // RFC 4180 quoting, with the tab standing in for the comma.
+  return NEEDS_QUOTING.test(text)
+    ? `"${text.replace(/"/g, '""')}"`
+    : text;
+}
+
+export function buildTsv(sections: TsvSection[]): string {
+  const records: string[] = [];
+
+  sections.forEach((section, index) => {
+    if (index > 0) {
+      records.push('');
+    }
+    if (section.headers) {
+      records.push(toRecord(section.headers));
+    }
+    section.rows.forEach((row) => records.push(toRecord(row)));
+  });
+
+  if (!records.length) {
+    return TSV_BOM;
+  }
+  return TSV_BOM + records.join(RECORD_SEPARATOR) + RECORD_SEPARATOR;
+}
+
+export function tsvFileName(
+  dashboardName: string,
+  position: number,
+  suffix: string
+): string {
+  const sanitized = (dashboardName || '').replace(ILLEGAL_IN_FILE_NAME, '_');
+  // A name made only of separators and whitespace carries no information, and
+  // leading underscores read as a broken export.
+  const name = /[^_\s]/.test(sanitized) ? sanitized.trim() : 'dashboard';
+  return `${name}_${position}_${suffix}.csv`;
+}
+
+export function downloadTsv(fileName: string, tsv: string): void {
+  saveAs(
+    new Blob([tsv], {type: 'text/tab-separated-values;charset=utf-8'}),
+    fileName
+  );
+}
+
+function toRecord(fields: string[]): string {
+  return fields.map(escapeTsvField).join(FIELD_SEPARATOR);
+}

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/i18n/da.ts
@@ -99,6 +99,7 @@ export const da = {
   'answers': 'svar',
   'No raw data found': 'Ingen rådata fundet',
   'Export raw data': 'Eksportér rådata',
+  'Export to CSV': 'Eksportér til CSV',
   'Id': 'Id',
   'Microting UID': 'Microting UID',
   'Duration': 'Varighed',

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/i18n/en-US.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/i18n/en-US.ts
@@ -88,6 +88,7 @@ export const enUS = {
   'answers': 'answers',
   'No raw data found': 'No raw data found',
   'Export raw data': 'Export raw data',
+  'Export to CSV': 'Export to CSV',
   'Id': 'Id',
   'Microting UID': 'Microting UID',
   'Duration': 'Duration',


### PR DESCRIPTION
Each dashboard item renders up to three tables — the aggregated chart data table, the raw data table, and the interviews table for text questions — and none of them could be taken out as a data file. All three now carry an export button.

The extension is `.csv` and the delimiter is a tab. That contradiction is deliberate and requested: users ask for "CSV", but Excel on a Danish locale opens tab-delimited text without a wizard, and a tab practically never occurs inside survey text.

## How it works

Everything is built and downloaded **in the browser** — no new endpoint, no backend change, no `-base` change.

| Table | Button | Data source |
|---|---|---|
| Aggregated chart data | `dashboardChartDataExportCsv{n}` | Already client-side |
| Raw data | `dashboardRawDataExportCsv{n}`, beside the existing xlsx button | One more call to the existing endpoint at `pageSize: total` in the grid's current sort order |
| Interviews | `dashboardInterviewsExportCsv{n}`, replacing the commented-out button | Already client-side |

`helpers/tsv-export.helper.ts` is the only place the delimiter, the RFC 4180 quoting rule (a field containing a tab, newline or quote gets quoted, inner quotes doubled) and the UTF-8 BOM live. The BOM matters — without it Excel guesses the code page and mangles `æ ø å`.

## Decisions worth reviewing

- **The raw data CSV carries exactly the columns the grid is showing**, so the column picker decides what lands in the file. The existing xlsx export is untouched and still carries every column, hidden ones included. The CSV is "what I am looking at"; the xlsx is "everything".
- **The stacked grouped chart exports as one section per block** rather than splitting percentages from amounts. Its header row already names both halves side by side — verified against live data, where a six-cell header sits above rows of three percentages followed by three amounts — so splitting would misalign the headers rather than fix them. Every other chart type stacks the two tables on screen and so stacks them in the file, separated by a blank record.
- **Percent cells keep the `%`** so the file matches the table, except where `calculateAverage` is set. The grouped template appends `%` unconditionally; the export does not reproduce that, because writing `4.2%` for an average of 4.2 would be actively wrong in a data file.
- **`Finished at` exports as the grid renders it**, which today is a full `Date.toString()`. Formatting it is a change to the raw data table itself, left as a follow-up rather than smuggled in here — a CSV that disagreed with the screen would be worse than an ugly date.

## Testing

**Jest** — 46 passing: the helper's escaping, BOM, section and filename rules, plus each component's export output (both chart shapes, `calculateAverage`, multi-block, the `pageSize: total` refetch, visible-columns-only, translated vs database headers, and the empty and failure paths). The chart-data and interviews suites were also migrated off the removed `async` import from `@angular/core/testing` so they compile again.

**Playwright** — 7 new tests in `c/insight-dashboard-csv-export.spec.ts`, covering the BOM/tab/CRLF contract, filenames, both chart export shapes, the full-result raw data export, the hidden-column rule, and the interviews table. New `DashboardCsvExport.data.ts` carries a `Linje` item and a `Vandret Bjælke Stablet Grupperet` item so both shapes are exercised, plus a third item on the survey's text question. A text first question hides the period and chart type controls, hence the new `fillTextQuestionItem`.

**Manually verified** against live dashboard data: all three files download, correct MIME type, BOM bytes `EF BB BF`, and the raw data export produced all 53 answers across exactly the 26 visible columns, matching the on-screen header row cell for cell.

Note for reviewers: the Playwright suite needs the `420_SDK.sql` seed and the `admin@admin.com` account, so it could not be run on a developer machine — CI is its first real execution. 18 other plugin jest suites still fail to compile on the same legacy `async` import; those were left alone.

Design doc: `docs/superpowers/specs/2026-08-06-dashboard-table-csv-export-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
