### PR TITLE
fix: repair both Excel exports and the CSV regressions review found

### DIFF
--- a/docs/superpowers/specs/2026-08-06-dashboard-table-csv-export-design.md
+++ b/docs/superpowers/specs/2026-08-06-dashboard-table-csv-export-design.md
@@ -202,10 +202,15 @@ One new key in `i18n/en-US.ts` and `i18n/da.ts`:
 | Raw data refetch fails or returns `success: false` | no file written, `loading` cleared; the grid's own error surface already covers the request |
 | Dashboard name empty or all-illegal characters | filename falls back to `dashboard_{position}_…` |
 
-There is no row cap on the raw-data CSV. The server-side `.xlsx` export refuses
-above 100 000 rows because it builds an OpenXML document in server memory; the
-CSV is a string built in the browser from a response the same endpoint already
-serves, so the constraint does not transfer.
+The raw-data CSV is capped at the same 50 000 rows the `.xlsx` export refuses
+above, enforced in `GetRawData` before the query runs.
+
+An earlier version of this section said there was no cap, on the grounds that the
+CSV is built in the browser from a response the endpoint already serves. That was
+wrong twice: the `.xlsx` limit is 50 000 rather than the 100 000 stated, and the
+endpoint had only ever been called with UI page sizes — asking it for the whole
+result is precisely what removes the bound its own comment calls "what makes a
+large export safe".
 
 ## Testing
 

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/InterviewsExportUTests.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn.Test/InterviewsExportUTests.cs
@@ -1,0 +1,203 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2021 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace InsightDashboard.Pn.Test;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using Infrastructure.Consts;
+using Infrastructure.Enum.Excel;
+using Infrastructure.Models.Export;
+using NUnit.Framework;
+using Services.InterviewsExcelService;
+
+/// <summary>
+/// Covers the interviews xlsx export. Like the raw data export tests these need
+/// no database - each writes a workbook to a temp file and reads it back.
+///
+/// The export shipped broken for a long time because nothing here existed: it
+/// wrote no header row at all, and stopped one column short of Comments, which
+/// is the only column an interviews export is really for.
+/// </summary>
+[TestFixture]
+public class InterviewsExportUTests
+{
+    private string _file;
+
+    [SetUp]
+    public void SetUp() =>
+        _file = Path.Combine(Path.GetTempPath(), $"interviews-{Guid.NewGuid():N}.xlsx");
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (File.Exists(_file))
+        {
+            File.Delete(_file);
+        }
+    }
+
+    private static InterviewsExcelService Service() => new(null, null);
+
+    private static InterviewsExportModel Interview() => new()
+    {
+        Id = 42,
+        Date = new DateTime(2021, 3, 14, 13, 45, 0),
+        Question = "Her kan du evt. uddybe dine svar:",
+        FilterQuestion = "Ønsker borgeren at deltage?",
+        FilterAnswer = "Ja",
+        Tag = "Team Nord",
+        Comments = "Maden er for kold",
+    };
+
+    /// <summary>
+    /// Resolves a cell to the text a reader would see. Values written as shared
+    /// strings hold an index rather than the string, so reading CellValue alone
+    /// silently returns a number.
+    /// </summary>
+    private static string Text(SpreadsheetDocument document, Cell cell)
+    {
+        var raw = cell.CellValue?.Text ?? string.Empty;
+
+        if (cell.DataType?.Value == CellValues.SharedString)
+        {
+            return document.WorkbookPart!.SharedStringTablePart!.SharedStringTable
+                .ElementAt(int.Parse(raw)).InnerText;
+        }
+
+        return cell.DataType?.Value == CellValues.InlineString ? cell.InnerText : raw;
+    }
+
+    /// <summary>Cell reference to text, so a gap is visible as a missing key.</summary>
+    private static List<Dictionary<string, string>> ReadSheet(string path)
+    {
+        using var document = SpreadsheetDocument.Open(path, false);
+        var worksheetPart = document.WorkbookPart!.WorksheetParts.First();
+
+        return worksheetPart.Worksheet
+            .Descendants<Row>()
+            .Select(row => row.Elements<Cell>()
+                .ToDictionary(
+                    cell => cell.CellReference?.Value ?? string.Empty,
+                    cell => Text(document, cell)))
+            .ToList();
+    }
+
+    [Test]
+    public void ColCount_CoversEveryColumnTheEnumDeclares()
+    {
+        // The constant was 6 while the enum declared 7, so the writer's loop
+        // never reached Comments. Pinning them together stops that recurring
+        // the next time a column is added.
+        Assert.That(
+            ExcelConsts.Interviews.ColCount,
+            Is.EqualTo(Enum.GetValues<InterviewsExport>().Length));
+    }
+
+    [Test]
+    public void Export_WritesAHeaderRowNamingEveryColumn()
+    {
+        Service().WriteInterviewsExportToExcelFile([Interview()], _file);
+
+        var sheet = ReadSheet(_file);
+
+        Assert.That(sheet, Is.Not.Empty, "The workbook must have a header row.");
+        Assert.That(sheet[0]["A1"], Is.EqualTo("Id"));
+        Assert.That(sheet[0]["B1"], Is.EqualTo("Date"));
+        Assert.That(sheet[0]["G1"], Is.EqualTo("Comments"));
+    }
+
+    [Test]
+    public void Export_WritesTheCommentsColumn()
+    {
+        Service().WriteInterviewsExportToExcelFile([Interview()], _file);
+
+        var sheet = ReadSheet(_file);
+
+        Assert.That(sheet[1].ContainsKey("G2"), Is.True, "Comments must be written.");
+        Assert.That(sheet[1]["G2"], Is.EqualTo("Maden er for kold"));
+    }
+
+    [Test]
+    public void Export_WritesEveryEnumMemberAsAColumn()
+    {
+        Service().WriteInterviewsExportToExcelFile([Interview()], _file);
+
+        var sheet = ReadSheet(_file);
+        var columns = Enum.GetValues<InterviewsExport>().Length;
+
+        for (var col = 1; col <= columns; col++)
+        {
+            var reference = $"{(char)('A' + col - 1)}2";
+            Assert.That(
+                sheet[1].ContainsKey(reference) && sheet[1][reference].Length > 0,
+                Is.True,
+                $"{(InterviewsExport)col} should have produced a value at {reference}.");
+        }
+    }
+
+    [Test]
+    public void Export_KeepsColumnsAlignedWhenAValueIsNull()
+    {
+        var interview = Interview();
+        interview.Tag = null;
+
+        Service().WriteInterviewsExportToExcelFile([interview], _file);
+
+        var sheet = ReadSheet(_file);
+
+        // The gap has to stay a gap. Shifting Comments left into F would put it
+        // under the Tag header without anything looking wrong.
+        Assert.That(sheet[1].ContainsKey("F2"), Is.False);
+        Assert.That(sheet[1]["G2"], Is.EqualTo("Maden er for kold"));
+    }
+
+    [Test]
+    public void Export_FormatsDatesUnambiguously()
+    {
+        Service().WriteInterviewsExportToExcelFile([Interview()], _file);
+
+        var sheet = ReadSheet(_file);
+
+        // 03/14/2021 is unreadable to a Danish audience and sorts lexically.
+        Assert.That(sheet[1]["B2"], Is.EqualTo("2021-03-14 13:45:00"));
+    }
+
+    [Test]
+    public void Export_ProducesAReadableWorkbookForAnEmptyInterviewList()
+    {
+        Service().WriteInterviewsExportToExcelFile([], _file);
+
+        var sheet = ReadSheet(_file);
+
+        // Reopening it at all is half the assertion; the header must survive so
+        // the user sees an empty table rather than an empty file.
+        Assert.That(sheet.Count, Is.EqualTo(1));
+        Assert.That(sheet[0]["A1"], Is.EqualTo("Id"));
+    }
+}

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Consts/ExcelConsts.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Infrastructure/Consts/ExcelConsts.cs
@@ -23,16 +23,21 @@ SOFTWARE.
 */
 namespace InsightDashboard.Pn.Infrastructure.Consts;
 
+using InsightDashboard.Pn.Infrastructure.Enum.Excel;
+
 public class ExcelConsts
 {
-    public const string ExcelTemplatesDir = "Templates";
-
     public static class Interviews
     {
-        public const int TemplateSheetNumber = 1;
-        public const string TemplateName = "interviews-template";
+        public const int HeaderRow = 1;
         public const int StartRow = 2;
         public const int StartCol = 1;
-        public const int ColCount = 6;
+
+        /// <summary>
+        /// Derived from the enum rather than written out. Hardcoded as 6 against a
+        /// seven member enum, it silently dropped the Comments column - the column
+        /// an interviews export exists for.
+        /// </summary>
+        public static readonly int ColCount = System.Enum.GetValues<InterviewsExport>().Length;
     }
 }

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Services/InterviewsExcelService/IInterviewsExcelService.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Services/InterviewsExcelService/IInterviewsExcelService.cs
@@ -29,5 +29,11 @@ using Infrastructure.Models.Export;
 public interface IInterviewsExcelService
 {
     bool WriteInterviewsExportToExcelFile(List<InterviewsExportModel> excelModel, string destFile);
-    string CopyTemplateForNewAccount(string templateId);
+
+    /// <summary>
+    /// Path for a new export file. The writer supplies its own header row, so
+    /// there is no template to copy - the previous copy was truncated by
+    /// SpreadsheetDocument.Create before anything was written to it anyway.
+    /// </summary>
+    string CreateFilePath();
 }

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Services/InterviewsExcelService/InterviewsExcelService.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Services/InterviewsExcelService/InterviewsExcelService.cs
@@ -74,54 +74,77 @@ public class InterviewsExcelService(
         // Get the sheet data to populate
         SheetData sheetData = worksheetPart.Worksheet.GetFirstChild<SheetData>();
 
-        // Get the column count and start from the specified row
-        int colCount = ExcelConsts.Interviews.ColCount; // Assuming `ColCount` is defined
+        int colCount = ExcelConsts.Interviews.ColCount;
+
+        // The header row is written here rather than inherited from a template.
+        // The old code copied an xlsx template and then opened the copy with
+        // SpreadsheetDocument.Create, which truncates it - so the headers, widths
+        // and styles the template existed to supply were destroyed before the
+        // first row was written, and every export arrived unlabelled.
+        Row headerRow = new Row { RowIndex = (uint)ExcelConsts.Interviews.HeaderRow };
+
+        for (var col = ExcelConsts.Interviews.StartCol; col <= colCount; col++)
+        {
+            headerRow.Append(new Cell
+            {
+                CellReference = GetCellReference(ExcelConsts.Interviews.HeaderRow, col),
+                DataType = CellValues.String,
+                CellValue = new CellValue(HeaderFor((InterviewsExport)col)),
+            });
+        }
+
+        sheetData!.Append(headerRow);
+
         int rowIndex = ExcelConsts.Interviews.StartRow;
 
-        // Iterate through each excelModel row
         foreach (var excelRow in excelModel)
         {
             Row row = new Row() { RowIndex = (uint)rowIndex };
 
             for (var col = ExcelConsts.Interviews.StartCol; col <= colCount; col++)
             {
-                var columnIndex = (InterviewsExport)col;
+                var columnName = ((InterviewsExport)col).ToString();
+                var value = excelRow?.GetType().GetProperty(columnName)?.GetValue(excelRow, null);
 
-                if (columnIndex > 0)
+                // A null leaves its cell out entirely. Every cell carries an
+                // absolute reference, so the gap stays where it belongs rather
+                // than shifting later columns under the wrong header.
+                if (value == null)
                 {
-                    var columnName = columnIndex.ToString();
-                    if (!string.IsNullOrEmpty(columnName))
-                    {
-                        var value = excelRow?.GetType().GetProperty(columnName)?.GetValue(excelRow, null);
-
-                        if (value != null)
-                        {
-                            Cell cell = new Cell() { CellReference = GetCellReference(rowIndex, col) };
-
-                            if (value is DateTime dateTime)
-                            {
-                                cell.DataType = CellValues.String;
-                                cell.CellValue = new CellValue(dateTime.ToString(CultureInfo.InvariantCulture));
-                            }
-                            else if (value is decimal decimalValue)
-                            {
-                                cell.DataType = CellValues.Number;
-                                cell.CellValue =
-                                    new CellValue(decimalValue.ToString("0.00", CultureInfo.InvariantCulture));
-                            }
-                            else
-                            {
-                                cell.DataType = CellValues.String;
-                                cell.CellValue = new CellValue(value.ToString());
-                            }
-
-                            row.Append(cell);
-                        }
-                    }
+                    continue;
                 }
+
+                Cell cell = new Cell() { CellReference = GetCellReference(rowIndex, col) };
+
+                switch (value)
+                {
+                    case DateTime dateTime:
+                        cell.DataType = CellValues.String;
+                        // Not InvariantCulture: that renders 03/14/2021, which is
+                        // ambiguous beside dd/MM/yyyy and sorts lexically.
+                        cell.CellValue = new CellValue(
+                            dateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+                        break;
+                    case int intValue:
+                        cell.DataType = CellValues.Number;
+                        cell.CellValue = new CellValue(
+                            intValue.ToString(CultureInfo.InvariantCulture));
+                        break;
+                    case decimal decimalValue:
+                        cell.DataType = CellValues.Number;
+                        cell.CellValue = new CellValue(
+                            decimalValue.ToString("0.00", CultureInfo.InvariantCulture));
+                        break;
+                    default:
+                        cell.DataType = CellValues.String;
+                        cell.CellValue = new CellValue(value.ToString());
+                        break;
+                }
+
+                row.Append(cell);
             }
 
-            sheetData!.Append(row);
+            sheetData.Append(row);
             rowIndex++;
         }
 
@@ -130,6 +153,15 @@ public class InterviewsExcelService(
 
         return true;
     }
+
+    /// <summary>Column header text. CamelCase enum members become spaced words.</summary>
+    private static string HeaderFor(InterviewsExport column) =>
+        column switch
+        {
+            InterviewsExport.FilterQuestion => "Filter Question",
+            InterviewsExport.FilterAnswer => "Filter Answer",
+            _ => column.ToString(),
+        };
 
     // Helper method to get cell reference like "A1", "B2", etc.
     private string GetCellReference(int rowIndex, int colIndex)
@@ -195,48 +227,17 @@ public class InterviewsExcelService(
     }
 
     /// <summary>
-    /// Copy template file to new excel file
+    /// Path for a new export file, mirroring RawDataExcelService.CreateFilePath.
     /// </summary>
-    /// <param name="templateId">The template identifier.</param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentNullException">userId</exception>
-    public string CopyTemplateForNewAccount(string templateId)
+    public string CreateFilePath()
     {
-        string destFile = null;
-        try
+        var userId = UserId;
+        if (userId <= 0)
         {
-            var userId = UserId;
-            if (userId <= 0)
-            {
-                throw new ArgumentNullException(nameof(userId));
-            }
-
-            var assembly = typeof(EformInsightDashboardPlugin).GetTypeInfo().Assembly;
-            var resourceStream = assembly.GetManifestResourceStream(
-                $"InsightDashboard.Pn.Resources.Templates.{templateId}.xlsx");
-
-            destFile = GetFilePathForUser(userId, templateId);
-            if (File.Exists(destFile))
-            {
-                File.Delete(destFile);
-            }
-
-            using var fileStream = File.Create(destFile!);
-            resourceStream?.Seek(0, SeekOrigin.Begin);
-            resourceStream?.CopyTo(fileStream);
-
-            return destFile;
+            throw new ArgumentNullException(nameof(userId));
         }
-        catch (Exception e)
-        {
-            logger.LogError(e, e.Message);
-            if (File.Exists(destFile))
-            {
-                File.Delete(destFile);
-            }
 
-            return null;
-        }
+        return GetFilePathForUser(userId, "interviews");
     }
 
     #endregion

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Services/InterviewsService/InterviewsService.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Services/InterviewsService/InterviewsService.cs
@@ -97,7 +97,7 @@ public class InterviewsService : IInterviewsService
                 interviews.Add(interviewsExportModel);
             }
 
-            excelFile = _interviewsExcelService.CopyTemplateForNewAccount("interviews-template");
+            excelFile = _interviewsExcelService.CreateFilePath();
             bool writeResult = _interviewsExcelService.WriteInterviewsExportToExcelFile(
                 interviews,
                 excelFile);

--- a/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Services/RawDataService/RawDataService.cs
+++ b/eFormAPI/Plugins/InsightDashboard.Pn/InsightDashboard.Pn/Services/RawDataService/RawDataService.cs
@@ -101,6 +101,20 @@ public class RawDataService : IRawDataService
     {
         try
         {
+            // Peak memory here is bounded by PageSize, and the browser's CSV export
+            // asks for the whole result in one page. Refuse the same sizes the xlsx
+            // export refuses, before touching the database - otherwise the CSV path
+            // is a way around a limit the Excel path enforces on the same data.
+            if (requestModel.PageSize > ExportRowLimit)
+            {
+                return new OperationDataResult<RawDataListModel>(
+                    false,
+                    string.Format(
+                        _localizationService.GetString("RawDataExportTooLarge"),
+                        requestModel.PageSize,
+                        ExportRowLimit));
+            }
+
             var core = await _coreHelper.GetCore();
             await using var sdkContext = core.DbContextHelper.GetDbContext();
 
@@ -214,7 +228,12 @@ public class RawDataService : IRawDataService
                     dashboardId, dashboardItemId, written, total);
             }
 
-            return new OperationDataResult<string>(true, filePath);
+            // The three-argument constructor is deliberate. OperationDataResult<T>
+            // declares both (bool, string message) and (bool, T model); when T is
+            // itself string the two-argument call binds to the message overload,
+            // which left Model null on every successful export and had the
+            // controller open a FileStream on null.
+            return new OperationDataResult<string>(true, string.Empty, filePath);
         }
         catch (Exception e)
         {

--- a/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/insight-dashboard-raw-data.spec.ts
+++ b/eform-client/playwright/e2e/plugins/insight-dashboard-pn/c/insight-dashboard-raw-data.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import * as fs from 'fs';
 import { LoginPage } from '../../../Page objects/Login.page';
 import { InsightDashboardPage } from '../InsightDashboard.page';
 import { InsightDashboardDashboardsPage } from '../InsightDashboard-Dashboards.page';
@@ -113,6 +114,30 @@ test.describe('InSight Dashboard - Raw data table', () => {
       // Question columns are labelled "N - question text".
       expect(questionPart.trim()).toMatch(/^\d+\s/);
     }
+  });
+
+  test('downloads a real workbook from the Excel export button', async () => {
+    await ensureExpanded(0);
+
+    // This asserts the bytes, not the click. The export previously answered 500
+    // for every item on every dashboard - RawDataService returned the file path
+    // in Message rather than Model, because OperationDataResult<string> binds a
+    // two-argument call to its (bool, string message) overload - and no test at
+    // any level noticed, because none of them crossed the HTTP boundary.
+    const [download] = await Promise.all([
+      page.waitForEvent('download', { timeout: 60000 }),
+      dashboardsViewPage.rawDataExportButton(0).click(),
+    ]);
+
+    expect(download.suggestedFilename()).toMatch(/\.xlsx$/);
+
+    const savedTo = await download.path();
+    expect(savedTo).not.toBeNull();
+
+    const bytes = fs.readFileSync(savedTo as string);
+    // Every xlsx is a zip container, so the first two bytes are "PK".
+    expect(bytes.subarray(0, 2).toString('latin1')).toBe('PK');
+    expect(bytes.length).toBeGreaterThan(1000);
   });
 
   test('keeps audit columns out of the default view', async () => {

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.spec.ts
@@ -187,10 +187,12 @@ describe('DashboardChartDataViewComponent', () => {
       );
     });
 
-    it('pads grouped headers that match neither half', () => {
+    it('pads grouped headers that cover less than the data', () => {
+      // One header over four value columns: duplication reaches two, so the
+      // remaining two are padded rather than left unnamed-and-missing.
       setUp(DashboardChartTypesEnum.HorizontalBarStackedGrouped, [
         {
-          rawHeaders: ['16_01', '16_05', '16_09'],
+          rawHeaders: ['16_01'],
           rawDataItems: [
             {
               rawValueName: 'Location 1',
@@ -203,8 +205,44 @@ describe('DashboardChartDataViewComponent', () => {
       ]);
       component.exportToCsv();
 
-      const records = exportedTsv().split('\r\n');
-      expect(records[0].split('\t').length).toBe(records[1].split('\t').length);
+      expect(exportedTsv()).toBe(
+        `${tsvExport.TSV_BOM}` +
+          '\t\t16_01\t16_01\t\t\r\n' +
+          'Location 1\tGlad\t82%\t74%\t41\t33\r\n'
+      );
+    });
+
+    it('sizes a grouped section to its widest row, not its first', () => {
+      // The backend sizes each location's array from that location's own option
+      // count, while rawHeaders is fixed from the first location. A narrow first
+      // location must not truncate the wider ones into a ragged file.
+      setUp(DashboardChartTypesEnum.HorizontalBarStackedGrouped, [
+        {
+          rawHeaders: ['16_01', '16_05', '16_09', '16_13'],
+          rawDataItems: [
+            {
+              rawValueName: 'Narrow',
+              rawDataValues: [
+                {valueName: 'Glad', percents: [82], amounts: [41]},
+              ],
+            },
+            {
+              rawValueName: 'Wide',
+              rawDataValues: [
+                {valueName: 'Glad', percents: [61, 39], amounts: [22, 14]},
+              ],
+            },
+          ],
+        },
+      ]);
+      component.exportToCsv();
+
+      const records = exportedTsv().split('\r\n').filter((r) => r.length);
+      const widths = records.map((record) => record.split('\t').length);
+      expect(widths).toEqual([6, 6, 6]);
+      // The short row is padded on the right, keeping its own values in place.
+      expect(records[1]).toBe('Narrow\tGlad\t82%\t41\t\t');
+      expect(records[2]).toBe('Wide\tGlad\t61%\t39%\t22\t14');
     });
 
     it('writes every block, separated by a blank record', () => {

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-chart-data-view/dashboard-chart-data-view.component.ts
@@ -94,12 +94,17 @@ export class DashboardChartDataViewComponent implements OnInit, OnDestroy {
         );
         // The two leading cells are the group and the value name; the rest are
         // the percentages and amounts the headers have to cover.
+        //
+        // Take the widest row, not the first. The backend sizes each location's
+        // array from that location's own option count while RawHeaders is fixed
+        // from the first location, so a block whose locations offer different
+        // numbers of options produces rows of differing widths.
         const valueWidth = rows.length
-          ? rows[0].length - 2
+          ? Math.max(...rows.map((row) => row.length)) - 2
           : block.rawHeaders.length;
         sections.push({
           headers: ['', '', ...this.groupedHeaders(block.rawHeaders, valueWidth)],
-          rows,
+          rows: rows.map((row) => this.padRow(row, valueWidth + 2)),
         });
         continue;
       }
@@ -136,6 +141,14 @@ export class DashboardChartDataViewComponent implements OnInit, OnDestroy {
    * narrower than its records is not a table any spreadsheet can read, so this
    * is one place the export deliberately does not reproduce the screen.
    */
+  /** A short row is padded rather than left ragged, so the section stays a table. */
+  private padRow(row: string[], width: number): string[] {
+    if (row.length >= width) {
+      return row;
+    }
+    return [...row, ...new Array(width - row.length).fill('')];
+  }
+
   private groupedHeaders(rawHeaders: string[], valueWidth: number): string[] {
     const headers =
       rawHeaders.length >= valueWidth

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-interviews-view/dashboard-interviews-view.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-interviews-view/dashboard-interviews-view.component.html
@@ -8,6 +8,15 @@
   >
     <mat-icon>file_download</mat-icon>
   </button>
+  <button
+    mat-icon-button
+    color="accent"
+    (click)="exportToExcel()"
+    id="dashboardInterviewsExport{{itemModel.position}}"
+    [matTooltip]="'Export interviews' | translate"
+  >
+    <mat-icon>download</mat-icon>
+  </button>
 </div>
 
 <mtx-grid

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-interviews-view/dashboard-interviews-view.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-interviews-view/dashboard-interviews-view.component.spec.ts
@@ -53,6 +53,10 @@ describe('DashboardInterviewsViewComponent', () => {
   }));
 
   beforeEach(() => {
+    // jsdom has no object URL support, and file-saver reaches for it.
+    (URL as any).createObjectURL = jest.fn(() => 'blob:stub');
+    (URL as any).revokeObjectURL = jest.fn();
+
     downloadSpy = jest
       .spyOn(tsvExport, 'downloadTsv')
       .mockImplementation(() => {});
@@ -127,6 +131,30 @@ describe('DashboardInterviewsViewComponent', () => {
       setUp([]);
       component.exportToCsv();
       expect(downloadSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exportToExcel', () => {
+    it('requests the workbook for this dashboard item and saves it', () => {
+      setUp([{date: new Date(2026, 2, 2), locationName: 'A', commentary: 'B'}]);
+
+      component.exportToExcel();
+
+      expect(dashboardItemsServiceMock.exportInterviewsToExcel).toHaveBeenCalledWith({
+        dashboardId: 9,
+        itemId: 4,
+      });
+    });
+
+    it('is reachable from the template', () => {
+      setUp([{date: new Date(2026, 2, 2), locationName: 'A', commentary: 'B'}]);
+
+      // The method existed for years with no caller, which is why the defects
+      // in the workbook it produces were never noticed.
+      const button = fixture.nativeElement.querySelector(
+        '#dashboardInterviewsExport2'
+      );
+      expect(button).not.toBeNull();
     });
   });
 });

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-raw-data-view/dashboard-raw-data-view.component.spec.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-raw-data-view/dashboard-raw-data-view.component.spec.ts
@@ -1,9 +1,10 @@
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {NO_ERRORS_SCHEMA, Pipe, PipeTransform} from '@angular/core';
-import {of} from 'rxjs';
+import {of, throwError, Subject} from 'rxjs';
 import {TranslateService} from '@ngx-translate/core';
 import {DashboardRawDataViewComponent} from './dashboard-raw-data-view.component';
 import {InsightDashboardPnRawDataService} from '../../../../services';
+import {ToastrService} from 'ngx-toastr';
 import * as tsvExport from '../../../../helpers/tsv-export.helper';
 
 @Pipe({name: 'translate', standalone: false})
@@ -42,6 +43,8 @@ describe('DashboardRawDataViewComponent', () => {
     },
   };
 
+  const toastrMock = {error: jest.fn()};
+
   const rawDataServiceMock = {
     getRawData: jest.fn(() => of(response)),
     exportToExcel: jest.fn(() => of(new Blob())),
@@ -49,10 +52,12 @@ describe('DashboardRawDataViewComponent', () => {
 
   beforeEach(waitForAsync(() => {
     rawDataServiceMock.getRawData.mockClear();
+    toastrMock.error.mockClear();
     TestBed.configureTestingModule({
       declarations: [DashboardRawDataViewComponent, MockTranslatePipe],
       providers: [
         {provide: InsightDashboardPnRawDataService, useValue: rawDataServiceMock},
+        {provide: ToastrService, useValue: toastrMock},
         {
           provide: TranslateService,
           useValue: {
@@ -226,6 +231,64 @@ describe('DashboardRawDataViewComponent', () => {
 
       expect(downloadSpy).not.toHaveBeenCalled();
       expect(component.exportingCsv).toBe(false);
+    });
+
+    it('surfaces the reason the server refused instead of doing nothing', () => {
+      component.toggle();
+      rawDataServiceMock.getRawData.mockReturnValueOnce(
+        of({
+          success: false,
+          model: null,
+          message: 'Result of 200000 rows exceeds the limit of 50000',
+        } as any)
+      );
+
+      component.exportToCsv();
+
+      expect(toastrMock.error).toHaveBeenCalledWith(
+        'Result of 200000 rows exceeds the limit of 50000',
+        'Error',
+        expect.anything()
+      );
+    });
+
+    it('frees the button when the request fails at transport level', () => {
+      component.toggle();
+      rawDataServiceMock.getRawData.mockReturnValueOnce(
+        throwError(() => new Error('gateway timeout'))
+      );
+
+      component.exportToCsv();
+
+      // Left true, the template disables the button until a page reload.
+      expect(component.exportingCsv).toBe(false);
+      expect(downloadSpy).not.toHaveBeenCalled();
+    });
+
+    it('exports the columns visible at click time, not at response time', () => {
+      component.toggle();
+
+      const responses = new Subject<any>();
+      rawDataServiceMock.getRawData.mockReturnValueOnce(responses.asObservable());
+      component.exportToCsv();
+
+      // The dashboard hands us a new item model while the request is in flight.
+      // Collapsed, ngOnChanges clears the columns without refetching them.
+      component.toggle();
+      component.ngOnChanges({itemModel: {} as any});
+      expect(component.tableHeaders.length).toBe(0);
+
+      responses.next(response);
+      responses.complete();
+
+      // Reading tableHeaders in the callback would have selected no columns and
+      // written a file of blank lines under a perfectly good name.
+      expect(exportedTsv()).toBe(
+        `${tsvExport.TSV_BOM}` +
+          'Finished at\t2 – Områder › Kantine\r\n' +
+          '2026-03-02T08:14:22\tKantine\r\n' +
+          '2026-03-03T07:22:11\t\r\n'
+      );
     });
   });
 });

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-raw-data-view/dashboard-raw-data-view.component.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/view/dashboard-raw-data-view/dashboard-raw-data-view.component.ts
@@ -4,6 +4,7 @@ import {Observable, of, Subscription} from 'rxjs';
 import {Sort} from '@angular/material/sort';
 import {MtxGridColumn} from '@ng-matero/extensions/grid';
 import {TranslateService} from '@ngx-translate/core';
+import {ToastrService} from 'ngx-toastr';
 import {saveAs} from 'file-saver';
 import {PaginationModel} from 'src/app/common/models';
 import {updateTableSort} from 'src/app/common/helpers';
@@ -29,6 +30,7 @@ import {
 export class DashboardRawDataViewComponent implements OnChanges, OnDestroy {
   private translateService = inject(TranslateService);
   private rawDataService = inject(InsightDashboardPnRawDataService);
+  private toastrService = inject(ToastrService);
 
   @Input() dashboardViewModel: DashboardViewModel = new DashboardViewModel();
   @Input() itemModel: DashboardViewItemModel = new DashboardViewItemModel();
@@ -170,6 +172,20 @@ export class DashboardRawDataViewComponent implements OnChanges, OnDestroy {
       return;
     }
     this.exportingCsv = true;
+
+    // Snapshot what the grid is showing now. The dashboard can hand us a new
+    // itemModel while the request is in flight, and ngOnChanges empties
+    // tableHeaders - reading it in the callback would then select no columns at
+    // all and quietly download a file of blank lines.
+    const visibleFields = this.tableHeaders
+      .filter((header) => !header.hide)
+      .map((header) => header.field);
+    const fileName = tsvFileName(
+      this.dashboardViewModel.dashboardName,
+      this.itemModel.position,
+      'raw_data'
+    );
+
     this.exportCsvSub$ = this.rawDataService
       .getRawData({
         dashboardId: this.dashboardViewModel.id,
@@ -179,37 +195,38 @@ export class DashboardRawDataViewComponent implements OnChanges, OnDestroy {
         sort: this.sort,
         isSortDsc: this.isSortDsc,
       })
-      .subscribe((data) => {
-        this.exportingCsv = false;
-        if (!data || !data.success || !data.model) {
-          return;
-        }
-        const columns = data.model.columns.filter((column) =>
-          this.isVisible(column.field)
-        );
-        downloadTsv(
-          tsvFileName(
-            this.dashboardViewModel.dashboardName,
-            this.itemModel.position,
-            'raw_data'
-          ),
-          buildTsv([
-            {
-              headers: columns.map((column) => this.headerText(column)),
-              rows: data.model.rows.map((row) =>
-                columns.map((column) => this.cellText(row[column.field]))
-              ),
-            },
-          ])
-        );
+      .subscribe({
+        next: (data) => {
+          this.exportingCsv = false;
+          if (!data || !data.success || !data.model) {
+            // The server refuses a result larger than the export limit, and says
+            // so. Swallowing that left the user with a button that did nothing.
+            if (data && data.message) {
+              this.toastrService.error(data.message, 'Error', {timeOut: 10000});
+            }
+            return;
+          }
+          const columns = data.model.columns.filter((column) =>
+            visibleFields.includes(column.field)
+          );
+          downloadTsv(
+            fileName,
+            buildTsv([
+              {
+                headers: columns.map((column) => this.headerText(column)),
+                rows: data.model.rows.map((row) =>
+                  columns.map((column) => this.cellText(row[column.field]))
+                ),
+              },
+            ])
+          );
+        },
+        // A transport failure never reaches the next handler, and leaving the
+        // flag set disabled the button until the page was reloaded.
+        error: () => {
+          this.exportingCsv = false;
+        },
       });
-  }
-
-  private isVisible(field: string): boolean {
-    // mtx-grid toggles `hide` on the very objects handed to it, so this reads
-    // back whatever the user last chose in the column menu.
-    const column = this.tableHeaders.find((header) => header.field === field);
-    return !!column && !column.hide;
   }
 
   private headerText(column: RawDataColumnModel): string {

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/i18n/da.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/i18n/da.ts
@@ -100,6 +100,7 @@ export const da = {
   'No raw data found': 'Ingen rådata fundet',
   'Export raw data': 'Eksportér rådata',
   'Export to CSV': 'Eksportér til CSV',
+  'Export interviews': 'Eksportér interviews',
   'Id': 'Id',
   'Microting UID': 'Microting UID',
   'Duration': 'Varighed',

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/i18n/en-US.ts
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/i18n/en-US.ts
@@ -89,6 +89,7 @@ export const enUS = {
   'No raw data found': 'No raw data found',
   'Export raw data': 'Export raw data',
   'Export to CSV': 'Export to CSV',
+  'Export interviews': 'Export interviews',
   'Id': 'Id',
   'Microting UID': 'Microting UID',
   'Duration': 'Duration',


### PR DESCRIPTION
Two Excel exports were broken, one of them completely, and neither had a test that could see it. A review of #1509 also turned up defects in the CSV export that shipped with it.

## The raw data Excel export answered 500 for every item, always

```
System.ArgumentNullException: Value cannot be null. (Parameter 'path')
   at System.IO.FileStream..ctor(String path, FileMode mode)
   at InsightDashboard.Pn.Controllers.RawDataController.<ExportRawData>b__0
```

`RawDataService.ExportToFile` ended with `new OperationDataResult<string>(true, filePath)`. `OperationDataResult<T>` declares both `(bool, string message)` and `(bool, T model)` — with `T` of `string` those are the same signature, so the call bound to the **message** overload. `Model` stayed null and the controller opened a `FileStream` on it. Confirmed by probing the constructors directly:

```
ctor(Boolean success, String message)
ctor(Boolean success, String model)
Success=True  Model=[NULL]  Message=[/tmp/file.xlsx]
```

**Why no test caught it:** the six existing tests in `RawDataExportUTests` are good — they open the produced workbook and assert real cell values — but they call `CreateWriter` directly. Nothing ever called `ExportToFile`, and nothing crossed the HTTP boundary, which is where the bug was. The new Playwright test clicks the button and asserts the download is a real workbook (`PK` magic bytes, `.xlsx`, >1 KB).

## The interviews export was broken three ways, and unreachable

| Defect | Effect |
|---|---|
| `SpreadsheetDocument.Create` on a copied template truncates it | Every export had no header row. 9561 bytes of template in, 1715 out. |
| `ColCount = 6` against a 7-member enum | `Comments` — the column the export exists for — was never written. |
| `InvariantCulture` dates | `03/14/2021` to a Danish audience; sorts lexically. |

All three survived because `exportToExcel()` had **no caller** — the button had been commented out for years. The writer now emits its own header row (no template), `ColCount` derives from `Enum.GetValues<InterviewsExport>().Length`, dates are `yyyy-MM-dd HH:mm:ss`, and the button is wired up. `CopyTemplateForNewAccount` is replaced by `CreateFilePath`, mirroring `RawDataExcelService`.

Verified against live data:
```
row 1: Id | Date | Question | Filter Question | Filter Answer | Tag | Comments
row 2: 660 | 2026-06-10 07:51:27 | Her kan du evt. uddybe... | (D,E absent) | Team Øst (1150) | Nogen gange er jeg utilfreds med maden...
```
Row 2 also shows null alignment holding — no filter question, so `D2`/`E2` are absent and later columns stay under their own headers.

## CSV defects from the review of #1509

- **`pageSize: total` bypassed the 50 000-row guard** the xlsx export enforces on the same data, on a request whose own comment says peak memory is bounded by `pageSize`. `GetRawData` now refuses oversized pages before querying.
- **The grouped export was still ragged.** It sized the header from `rows[0]`, but the backend sizes each location's array from that location's own option count while `RawHeaders` is fixed from the first — so mixed-option locations gave a header narrower than its records, exactly what the previous fix's comment claimed to prevent. Now takes the widest row and pads short ones.
- **`exportingCsv` was never cleared on transport errors**, disabling the button until page reload.
- **An in-flight export whose item model changed** read an emptied `tableHeaders` and downloaded a correctly-named file of blank lines. Visible columns and filename are captured at click time.
- **Server refusals were swallowed**; now surfaced via toastr.

## Testing

- **7 new C# tests** (`InterviewsExportUTests`) — all 7 fail against the old code. Header row, Comments column, every enum member, null alignment, date format, empty list, and a guard pinning `ColCount` to the enum length.
- **13 passing** across both Excel fixtures; no new packages, no database needed.
- **54 Jest tests** including the widest-row grouped case, the transport-error path, and the click-time column snapshot. One asserts the interviews xlsx button exists in the DOM, so a caller-less export can't recur silently.
- **1 new Playwright test** asserting the raw-data xlsx download is a real workbook.
- The tautological `pads grouped headers` test the review flagged is replaced — it compared header width against a value derived from the same row, so it could not fail.

The design doc claimed the limit was 100 000 and did not apply to the CSV. Both wrong; corrected in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
