### PR TITLE
Cancel first in this plugin's dialogs

### DIFF
--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/answers/answer-delete-modal/answer-delete-modal.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/answers/answer-delete-modal/answer-delete-modal.component.html
@@ -1,17 +1,17 @@
 <h3 mat-dialog-title>{{'Are you sure you want to delete answer' | translate}}?</h3>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-delete"
-    id="saveDeleteBtn"
-    (click)="delete()"
-  >
-    {{'Delete' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="cancelDeleteBtn"
     (click)="hide()"
   >
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-delete"
+    id="saveDeleteBtn"
+    (click)="delete()"
+  >
+    {{'Delete' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/dashboard-new/dashboard-new.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/dashboard-new/dashboard-new.component.html
@@ -22,18 +22,18 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
+    class="btn-cancel"
+    id="dashboardCreateSaveCancelBtn"
+    (click)="hide()"
+  >
+    {{'Cancel' | translate}}
+  </button>
+  <button
     class="btn-primary"
     id="dashboardCreateSaveBtn"
     (click)="createDashboard()"
     [disabled]="!dashboardName && !selectedSurveyId"
   >
     {{'Save' | translate}}
-  </button>
-  <button
-    class="btn-cancel"
-    id="dashboardCreateSaveCancelBtn"
-    (click)="hide()"
-  >
-    {{'Cancel' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/edit/dashboard-copy/dashboard-copy.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/edit/dashboard-copy/dashboard-copy.component.html
@@ -11,17 +11,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-primary"
-    id="dashboardCopySaveBtn"
-    (click)="copyDashboard()"
-  >
-    {{'Copy' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="dashboardCopySaveCancelBtn"
     (click)="hide()"
   >
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-primary"
+    id="dashboardCopySaveBtn"
+    (click)="copyDashboard()"
+  >
+    {{'Copy' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/edit/dashboard-delete/dashboard-delete.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/dashboards/edit/dashboard-delete/dashboard-delete.component.html
@@ -15,17 +15,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-delete"
-    id="dashboardDeleteSaveBtn"
-    (click)="deleteDashboard()"
-  >
-    {{'Delete' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="dashboardDeleteCancelBtn"
     (click)="hide()"
   >
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-delete"
+    id="dashboardDeleteSaveBtn"
+    (click)="deleteDashboard()"
+  >
+    {{'Delete' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/surveys/survey-configuration-activate/survey-configuration-status.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/surveys/survey-configuration-activate/survey-configuration-status.component.html
@@ -4,17 +4,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-primary"
-    [id]="(selectedSurveyConfig.isActive ? 'surveyConfigDeactivateBtn' : 'surveyConfigActivateBtn')"
-    (click)="changeSurveyConfigStatus()"
-  >
-    {{ (selectedSurveyConfig.isActive ? 'Deactivate' : 'Activate') | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="surveyConfigDeleteCancelBtn"
     (click)="hide()"
   >
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-primary"
+    [id]="(selectedSurveyConfig.isActive ? 'surveyConfigDeactivateBtn' : 'surveyConfigActivateBtn')"
+    (click)="changeSurveyConfigStatus()"
+  >
+    {{ (selectedSurveyConfig.isActive ? 'Deactivate' : 'Activate') | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/surveys/survey-configuration-delete/survey-configuration-delete.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/surveys/survey-configuration-delete/survey-configuration-delete.component.html
@@ -27,17 +27,17 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
-    class="btn-delete"
-    id="surveyConfigDeleteSaveBtn"
-    (click)="deleteSurveyConfig()"
-  >
-    {{'Delete' | translate}}
-  </button>
-  <button
     class="btn-cancel"
     id="surveyConfigDeleteCancelBtn"
     (click)="hide()"
   >
     {{'Cancel' | translate}}
+  </button>
+  <button
+    class="btn-delete"
+    id="surveyConfigDeleteSaveBtn"
+    (click)="deleteSurveyConfig()"
+  >
+    {{'Delete' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/surveys/survey-configuration-edit/survey-configuration-edit.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/surveys/survey-configuration-edit/survey-configuration-edit.component.html
@@ -24,18 +24,18 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
+    class="btn-cancel"
+    id="surveyConfigEditSaveCancelBtn"
+    (click)="hide()"
+  >
+    {{'Cancel' | translate}}
+  </button>
+  <button
     class="btn-primary"
     (click)="updateConfig()"
     id="surveyConfigEditSaveBtn"
     [disabled]="!selectedSurveyConfig.surveyId && selectedLocations.length < 1"
   >
     {{'Save' | translate}}
-  </button>
-  <button
-    class="btn-cancel"
-    id="surveyConfigEditSaveCancelBtn"
-    (click)="hide()"
-  >
-    {{'Cancel' | translate}}
   </button>
 </div>

--- a/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/surveys/survey-configuration-new/survey-configuration-new.component.html
+++ b/eform-client/src/app/plugins/modules/insight-dashboard-pn/components/surveys/survey-configuration-new/survey-configuration-new.component.html
@@ -22,18 +22,18 @@
 </div>
 <div mat-dialog-actions class="d-flex flex-row justify-content-end">
   <button
+    class="btn-cancel"
+    id="surveyConfigCreateSaveCancelBtn"
+    (click)="hide()"
+  >
+    {{'Cancel' | translate}}
+  </button>
+  <button
     class="btn-primary"
     (click)="createConfig()"
     id="surveyConfigCreateSaveBtn"
     [disabled]="!selectedSurveyId && selectedLocations.length < 1"
   >
     {{'Save' | translate}}
-  </button>
-  <button
-    class="btn-cancel"
-    id="surveyConfigCreateSaveCancelBtn"
-    (click)="hide()"
-  >
-    {{'Cancel' | translate}}
   </button>
 </div>


### PR DESCRIPTION
Ordering half of the button work. Depends on **microting/eform-angular-frontend#8017**, which decides the convention and teaches the shared gate to enforce it.

Reorders **8 dialog action rows** so the dismissing button leads.

## Why this was a separate decision

The [audit](https://claude.ai/code/artifact/bbbbd984-00fc-4f39-8a86-b98ac1b3c3df) deliberately left ordering open: 42 core dialogs and 48 plugin dialogs rendered `[Save][Cancel]` against 12 the other way, so cancel-first was the *minority*. It is also the one button inconsistency users actually feel — it moves the button under their cursor between one dialog and the next — so it warranted a decision rather than whichever way a sweep happened to run.

## It is a pure move

Whole `<button>` elements swap position; nothing is retyped. Verified by diffing removed against added lines in this repo — the line multisets are identical, so no `id`, binding, tooltip, icon or translate pipe changed in transit. That check is the point: a re-typed button is how an `id` silently disappears and takes an e2e selector with it.

No touched row carries `cdkFocusInitial`, so no autofocus target moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sXLtgzZU8QL9m84GqMkoJ